### PR TITLE
feat(admin): category management API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "server",
   "version": "1.0.0",
   "main": "index.ts",
-  "type": "commonjs",
+  "type": "module",
   "scripts": {
     "start": "node dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "server",
   "version": "1.0.0",
   "main": "index.ts",
-  "type": "module",
+  "type": "commonjs",
   "scripts": {
     "start": "node dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -6,6 +6,7 @@ import { IApiResponse } from '../../types/common/IApiResponse';
 import { SUCCESS_MESSAGES } from '../../shared/constants/messages';
 import { HTTP_STATUS, SUCCESS_STATUS } from '../../shared/constants/http_status_code';
 
+
 @injectable()
 export class AdminCategoryController implements IAdminCategoryController {
   constructor(
@@ -21,6 +22,21 @@ export class AdminCategoryController implements IAdminCategoryController {
     const successResponse: IApiResponse = {
       success: SUCCESS_STATUS.SUCCESS,
       message: SUCCESS_MESSAGES.CATEGORY_CREATED,
+    };
+
+    res.status(HTTP_STATUS.OK).json(successResponse);
+  });
+
+  updateCategory = asyncHandler(async (req, res) => {
+    const adminId = "12345"
+    const { id } = req.params;
+    const payload = req.body;
+console.log('all data', req.body)
+    await this._adminCategoryService.updateCategory(adminId, id, payload);
+
+    const successResponse: IApiResponse = {
+      success: SUCCESS_STATUS.SUCCESS,
+      message: SUCCESS_MESSAGES.CATEGORY_UPDATED,
     };
 
     res.status(HTTP_STATUS.OK).json(successResponse);

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -5,7 +5,9 @@ import asyncHandler from 'express-async-handler';
 import { IApiResponse } from '../../types/common/IApiResponse';
 import { SUCCESS_MESSAGES } from '../../shared/constants/messages';
 import { HTTP_STATUS, SUCCESS_STATUS } from '../../shared/constants/http_status_code';
-
+import { RequestHandler } from 'express';
+import { ParamsDictionary } from 'express-serve-static-core';
+import { ParsedQs } from 'qs';
 
 @injectable()
 export class AdminCategoryController implements IAdminCategoryController {
@@ -28,10 +30,9 @@ export class AdminCategoryController implements IAdminCategoryController {
   });
 
   updateCategory = asyncHandler(async (req, res) => {
-    const adminId = "12345"
+    const adminId = req.user?.id!;
     const { id } = req.params;
     const payload = req.body;
-console.log('all data', req.body)
     await this._adminCategoryService.updateCategory(adminId, id, payload);
 
     const successResponse: IApiResponse = {
@@ -39,6 +40,20 @@ console.log('all data', req.body)
       message: SUCCESS_MESSAGES.CATEGORY_UPDATED,
     };
 
+    res.status(HTTP_STATUS.OK).json(successResponse);
+  });
+
+  toggleCategoryStatus = asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    console.log('id')
+    const isActivated = await this._adminCategoryService.toggleCategoryStatus(id);
+   console.log('actate', isActivated)
+    const successResponse: IApiResponse = {
+      success: SUCCESS_STATUS.SUCCESS,
+      message: isActivated
+        ? SUCCESS_MESSAGES.CATEGORY_ACTIVATED
+        : SUCCESS_MESSAGES.CATEGORY_DEACTIVATED,
+    };
     res.status(HTTP_STATUS.OK).json(successResponse);
   });
 }

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -44,7 +44,6 @@ export class AdminCategoryController implements IAdminCategoryController {
   });
 
   toggleCategoryStatus = asyncHandler(async (req, res) => {
-    console.log('category paload', req.body);
     const { id } = req.params;
     const isActivated = await this._adminCategoryService.toggleCategoryStatus(id);
 

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -1,0 +1,13 @@
+
+import { inject, injectable } from "tsyringe";
+import { IAdminCategoryController } from "../../interfaces/controller_interfaces/admin/IAdminCategoryController";
+import { IAdminCategoryService } from "../../interfaces/service_interfaces/admin/ICategoryService";
+
+@injectable()
+export class AdminCategoryController implements IAdminCategoryController {
+    constructor(
+        @inject('IAdminCategoryService')
+        private _adminCategoryService: IAdminCategoryService,
+    ) { }
+    
+}

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -62,12 +62,10 @@ export class AdminCategoryController implements IAdminCategoryController {
     const { page, limit, search, selectedFilter } = getPaginationOptions(req);
     const filters: CategoryFilters = {
       status: selectedFilter as CategoryStatus,
-      search: search,
-      page: page || 1,
-      limit: limit || 10,
+      search,
+      page,
+      limit,
     };
-
-    console.log('finter option', filters);
 
     const result = await this._adminCategoryService.getAllCategories(filters);
 
@@ -77,6 +75,19 @@ export class AdminCategoryController implements IAdminCategoryController {
       data: result,
     };
 
+    res.status(HTTP_STATUS.OK).json(successResponse);
+  });
+
+  getPendingRequest = asyncHandler(async (req, res) => {
+    const { page, limit } = getPaginationOptions(req);
+
+    const result = await this._adminCategoryService.getPendingRequests(page, limit);
+
+    const successResponse: IApiResponse<typeof result> = {
+      success: SUCCESS_STATUS.SUCCESS,
+      message: SUCCESS_MESSAGES.OK,
+      data: result,
+    };
     res.status(HTTP_STATUS.OK).json(successResponse);
   });
 }

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -5,9 +5,11 @@ import asyncHandler from 'express-async-handler';
 import { IApiResponse } from '../../types/common/IApiResponse';
 import { SUCCESS_MESSAGES } from '../../shared/constants/messages';
 import { HTTP_STATUS, SUCCESS_STATUS } from '../../shared/constants/http_status_code';
-import { RequestHandler } from 'express';
-import { ParamsDictionary } from 'express-serve-static-core';
-import { ParsedQs } from 'qs';
+
+import { getPaginationOptions } from '../../shared/utils/pagination.helper';
+import { CategoryFilters } from '../../types/db';
+
+import { CategoryStatus } from '../../shared/constants/constants';
 
 @injectable()
 export class AdminCategoryController implements IAdminCategoryController {
@@ -45,15 +47,36 @@ export class AdminCategoryController implements IAdminCategoryController {
 
   toggleCategoryStatus = asyncHandler(async (req, res) => {
     const { id } = req.params;
-    console.log('id')
     const isActivated = await this._adminCategoryService.toggleCategoryStatus(id);
-   console.log('actate', isActivated)
+
     const successResponse: IApiResponse = {
       success: SUCCESS_STATUS.SUCCESS,
       message: isActivated
         ? SUCCESS_MESSAGES.CATEGORY_ACTIVATED
         : SUCCESS_MESSAGES.CATEGORY_DEACTIVATED,
     };
+    res.status(HTTP_STATUS.OK).json(successResponse);
+  });
+
+  getAllCategories = asyncHandler(async (req, res) => {
+    const { page, limit, search, selectedFilter } = getPaginationOptions(req);
+    const filters: CategoryFilters = {
+      status: selectedFilter as CategoryStatus,
+      search: search,
+      page: page || 1,
+      limit: limit || 10,
+    };
+
+    console.log('finter option', filters);
+
+    const result = await this._adminCategoryService.getAllCategories(filters);
+
+    const successResponse: IApiResponse<typeof result> = {
+      success: SUCCESS_STATUS.SUCCESS,
+      message: SUCCESS_MESSAGES.OK,
+      data: result,
+    };
+
     res.status(HTTP_STATUS.OK).json(successResponse);
   });
 }

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -44,6 +44,7 @@ export class AdminCategoryController implements IAdminCategoryController {
   });
 
   toggleCategoryStatus = asyncHandler(async (req, res) => {
+    console.log('category paload', req.body);
     const { id } = req.params;
     const isActivated = await this._adminCategoryService.toggleCategoryStatus(id);
 
@@ -77,9 +78,9 @@ export class AdminCategoryController implements IAdminCategoryController {
   });
 
   getPendingRequest = asyncHandler(async (req, res) => {
-    const { page, limit } = getPaginationOptions(req);
+    const { page, limit, search } = getPaginationOptions(req);
 
-    const result = await this._adminCategoryService.getPendingRequests(page, limit);
+    const result = await this._adminCategoryService.getPendingRequests(page, limit, search);
 
     const successResponse: IApiResponse<typeof result> = {
       success: SUCCESS_STATUS.SUCCESS,
@@ -90,7 +91,7 @@ export class AdminCategoryController implements IAdminCategoryController {
   });
 
   reviewCategoryRequest = asyncHandler(async (req, res) => {
-    const adminId = '68ea7bc7e534a813e0efdbe0';
+    const adminId = req.user?.id!;
     const { id } = req.params;
     const { action, rejectionReason } = req.body;
 
@@ -105,6 +106,24 @@ export class AdminCategoryController implements IAdminCategoryController {
         action === APPROVE_REJECT_ACTIONS.APPROVE
           ? SUCCESS_MESSAGES.CATEGORY_REQUEST_APPROVED
           : SUCCESS_MESSAGES.CATEGORY_REQUEST_REJECTED,
+    };
+    res.status(HTTP_STATUS.OK).json(successResponse);
+  });
+
+  getReviwedRequest = asyncHandler(async (req, res) => {
+    const { page, limit, search, selectedFilter } = getPaginationOptions(req);
+
+    const result = await this._adminCategoryService.getReviewedRequests(
+      page,
+      limit,
+      search,
+      selectedFilter,
+    );
+
+    const successResponse: IApiResponse<typeof result> = {
+      success: SUCCESS_STATUS.SUCCESS,
+      message: SUCCESS_MESSAGES.OK,
+      data: result,
     };
     res.status(HTTP_STATUS.OK).json(successResponse);
   });

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -5,12 +5,10 @@ import asyncHandler from 'express-async-handler';
 import { IApiResponse } from '../../types/common/IApiResponse';
 import { SUCCESS_MESSAGES } from '../../shared/constants/messages';
 import { HTTP_STATUS, SUCCESS_STATUS } from '../../shared/constants/http_status_code';
-
 import { getPaginationOptions } from '../../shared/utils/pagination.helper';
 import { CategoryFilters } from '../../types/db';
-
 import { CategoryStatus } from '../../shared/constants/constants';
-
+import { APPROVE_REJECT_ACTIONS } from '../../shared/constants/constants';
 @injectable()
 export class AdminCategoryController implements IAdminCategoryController {
   constructor(
@@ -87,6 +85,26 @@ export class AdminCategoryController implements IAdminCategoryController {
       success: SUCCESS_STATUS.SUCCESS,
       message: SUCCESS_MESSAGES.OK,
       data: result,
+    };
+    res.status(HTTP_STATUS.OK).json(successResponse);
+  });
+
+  reviewCategoryRequest = asyncHandler(async (req, res) => {
+    const adminId = '68ea7bc7e534a813e0efdbe0';
+    const { id } = req.params;
+    const { action, rejectionReason } = req.body;
+
+    await this._adminCategoryService.reviewCategoryRequest(adminId, id, {
+      action,
+      rejectionReason,
+    });
+
+    const successResponse: IApiResponse = {
+      success: SUCCESS_STATUS.SUCCESS,
+      message:
+        action === APPROVE_REJECT_ACTIONS.APPROVE
+          ? SUCCESS_MESSAGES.CATEGORY_REQUEST_APPROVED
+          : SUCCESS_MESSAGES.CATEGORY_REQUEST_REJECTED,
     };
     res.status(HTTP_STATUS.OK).json(successResponse);
   });

--- a/src/controllers/admin/admin.category.controller.ts
+++ b/src/controllers/admin/admin.category.controller.ts
@@ -1,13 +1,28 @@
-
-import { inject, injectable } from "tsyringe";
-import { IAdminCategoryController } from "../../interfaces/controller_interfaces/admin/IAdminCategoryController";
-import { IAdminCategoryService } from "../../interfaces/service_interfaces/admin/ICategoryService";
+import { inject, injectable } from 'tsyringe';
+import { IAdminCategoryController } from '../../interfaces/controller_interfaces/admin/IAdminCategoryController';
+import { IAdminCategoryService } from '../../interfaces/service_interfaces/admin/ICategoryService';
+import asyncHandler from 'express-async-handler';
+import { IApiResponse } from '../../types/common/IApiResponse';
+import { SUCCESS_MESSAGES } from '../../shared/constants/messages';
+import { HTTP_STATUS, SUCCESS_STATUS } from '../../shared/constants/http_status_code';
 
 @injectable()
 export class AdminCategoryController implements IAdminCategoryController {
-    constructor(
-        @inject('IAdminCategoryService')
-        private _adminCategoryService: IAdminCategoryService,
-    ) { }
-    
+  constructor(
+    @inject('IAdminCategoryService')
+    private _adminCategoryService: IAdminCategoryService,
+  ) {}
+
+  createCategory = asyncHandler(async (req, res) => {
+    const adminId = req.user?.id!;
+    const payload = req.body;
+    await this._adminCategoryService.createCategory(adminId, payload);
+
+    const successResponse: IApiResponse = {
+      success: SUCCESS_STATUS.SUCCESS,
+      message: SUCCESS_MESSAGES.CATEGORY_CREATED,
+    };
+
+    res.status(HTTP_STATUS.OK).json(successResponse);
+  });
 }

--- a/src/controllers/vendor/vendor-package.controller.ts
+++ b/src/controllers/vendor/vendor-package.controller.ts
@@ -18,7 +18,6 @@ export class VendorPackageController implements IVendorPackageController {
   ) {}
 
   createPackage = asyncHandler(async (req, res) => {
-
     const vendorId = req.user?.id!;
     const payload = req.body;
 

--- a/src/di/controller.registry.ts
+++ b/src/di/controller.registry.ts
@@ -15,6 +15,8 @@ import { IS3Controller } from '../interfaces/controller_interfaces/IS3Controller
 import { S3Controller } from '../controllers/s3.controller';
 import { IVendorPackageController } from '../interfaces/controller_interfaces/vendor/IVendorPackageController';
 import { VendorPackageController } from '../controllers/vendor/vendor-package.controller';
+import { AdminCategoryController } from '../controllers/admin/admin.category.controller';
+import { IAdminCategoryController } from '../interfaces/controller_interfaces/admin/IAdminCategoryController';
 export class ControllerRegistry {
   static registerControllers() {
     container.register<IAuthController>('IAuthController', {
@@ -38,6 +40,9 @@ export class ControllerRegistry {
     });
     container.register<IAdminVendorController>('IAdminVendorController', {
       useClass: AdminVendorController,
+    });
+    container.register<IAdminCategoryController>('IAdminCategoryController', {
+      useClass: AdminCategoryController,
     });
 
     //user controllers

--- a/src/di/repository.registry.ts
+++ b/src/di/repository.registry.ts
@@ -5,6 +5,8 @@ import { IVendorInfoRepository } from '../interfaces/repository_interfaces/IVend
 import { VendorInfoRepository } from '../repositories/vendor.info.repository';
 import { IBasePackageRepository } from '../interfaces/repository_interfaces/IBasePackageRepository';
 import { BasePackageRepository } from '../repositories/base-package-repository';
+import { ICategoryRepository } from '../interfaces/repository_interfaces/ICategoryRepository';
+import { CategoryRepository } from '../repositories/category.repository';
 export class RepositoryRegistry {
   static registerRepositories(): void {
     container.register<IUserRepository>('IUserRepository', {
@@ -19,6 +21,9 @@ export class RepositoryRegistry {
     });
     container.register<IBasePackageRepository>('IBasePackageRepository', {
       useClass: BasePackageRepository,
+    });
+    container.register<ICategoryRepository>('ICategoryRepository', {
+      useClass: CategoryRepository,
     });
 
     // Register other repositories here

--- a/src/di/service.registry.ts
+++ b/src/di/service.registry.ts
@@ -25,6 +25,8 @@ import { IFileStorageHandlerService } from '../interfaces/service_interfaces/IFi
 import { FileStorageHandlerService } from '../services/file.storage.handler.service';
 import { IPackageService } from '../interfaces/service_interfaces/vendor/IPackageService';
 import { PackageService } from '../services/vendor/package.service';
+import { IAdminCategoryService } from '../interfaces/service_interfaces/admin/ICategoryService';
+import { CategoryService } from '../services/admin/category.service';
 export class ServiceRegistry {
   static registerServices(): void {
     container.register<IAuthService>('IAuthService', {
@@ -73,6 +75,9 @@ export class ServiceRegistry {
     });
     container.register<IAdminVendorService>('IAdminVendorService', {
       useClass: AdminVendorService,
+    });
+    container.register<IAdminCategoryService>('IAdminCategoryService', {
+      useClass: CategoryService,
     });
 
     //user services

--- a/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
+++ b/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
@@ -6,4 +6,5 @@ export interface IAdminCategoryController {
   toggleCategoryStatus: RequestHandler;
   getAllCategories: RequestHandler;
   getPendingRequest: RequestHandler;
+  reviewCategoryRequest: RequestHandler;
 }

--- a/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
+++ b/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
@@ -4,4 +4,5 @@ export interface IAdminCategoryController {
   createCategory: RequestHandler;
   updateCategory: RequestHandler;
   toggleCategoryStatus: RequestHandler;
+  getAllCategories: RequestHandler;
 }

--- a/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
+++ b/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
@@ -2,4 +2,5 @@ import { RequestHandler } from 'express';
 
 export interface IAdminCategoryController {
   createCategory: RequestHandler;
+  updateCategory: RequestHandler;
 }

--- a/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
+++ b/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express';
 
 export interface IAdminCategoryController {
-
+  createCategory: RequestHandler;
 }

--- a/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
+++ b/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
@@ -1,0 +1,5 @@
+import { RequestHandler } from 'express';
+
+export interface IAdminCategoryController {
+
+}

--- a/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
+++ b/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
@@ -5,4 +5,5 @@ export interface IAdminCategoryController {
   updateCategory: RequestHandler;
   toggleCategoryStatus: RequestHandler;
   getAllCategories: RequestHandler;
+  getPendingRequest: RequestHandler;
 }

--- a/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
+++ b/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
@@ -3,4 +3,5 @@ import { RequestHandler } from 'express';
 export interface IAdminCategoryController {
   createCategory: RequestHandler;
   updateCategory: RequestHandler;
+  toggleCategoryStatus: RequestHandler;
 }

--- a/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
+++ b/src/interfaces/controller_interfaces/admin/IAdminCategoryController.ts
@@ -7,4 +7,5 @@ export interface IAdminCategoryController {
   getAllCategories: RequestHandler;
   getPendingRequest: RequestHandler;
   reviewCategoryRequest: RequestHandler;
+  getReviwedRequest: RequestHandler;
 }

--- a/src/interfaces/repository_interfaces/ICategoryRepository.ts
+++ b/src/interfaces/repository_interfaces/ICategoryRepository.ts
@@ -1,5 +1,5 @@
 import { IBaseRepository } from './IBaseRepository';
-import { ICategory } from '../../types/entities/category.entity';
+import { ICategory, ICategoryRequestPopulated } from '../../types/entities/category.entity';
 import { CategoryStatus } from '../../shared/constants/constants';
 import { CategoryFilters, CategoryFindAllResult } from '../../types/db';
 
@@ -8,4 +8,8 @@ export interface ICategoryRepository extends IBaseRepository<ICategory> {
   findBySlug(slug: string, excludeId?: string): Promise<ICategory | null>;
   toggleStatus(id: string, isActive: boolean, status: CategoryStatus): Promise<ICategory | null>;
   findAllCategory(filters: CategoryFilters): Promise<CategoryFindAllResult>;
+  findPendingRequests(
+    page: number,
+    limit: number,
+  ): Promise<{ requests: ICategoryRequestPopulated[]; total: number }>;
 }

--- a/src/interfaces/repository_interfaces/ICategoryRepository.ts
+++ b/src/interfaces/repository_interfaces/ICategoryRepository.ts
@@ -1,7 +1,9 @@
 import { IBaseRepository } from './IBaseRepository';
 import { ICategory } from '../../types/entities/category.entity';
+import { CategoryStatus } from 'shared/constants/constants';
 
 export interface ICategoryRepository extends IBaseRepository<ICategory> {
   findByName(name: string): Promise<ICategory | null>;
   findBySlug(slug: string, excludeId?: string): Promise<ICategory | null>;
+  toggleStatus(id: string, isActive: boolean, status: CategoryStatus): Promise<ICategory | null>;
 }

--- a/src/interfaces/repository_interfaces/ICategoryRepository.ts
+++ b/src/interfaces/repository_interfaces/ICategoryRepository.ts
@@ -1,9 +1,11 @@
 import { IBaseRepository } from './IBaseRepository';
 import { ICategory } from '../../types/entities/category.entity';
-import { CategoryStatus } from 'shared/constants/constants';
+import { CategoryStatus } from '../../shared/constants/constants';
+import { CategoryFilters, CategoryFindAllResult } from '../../types/db';
 
 export interface ICategoryRepository extends IBaseRepository<ICategory> {
   findByName(name: string): Promise<ICategory | null>;
   findBySlug(slug: string, excludeId?: string): Promise<ICategory | null>;
   toggleStatus(id: string, isActive: boolean, status: CategoryStatus): Promise<ICategory | null>;
+  findAllCategory(filters: CategoryFilters): Promise<CategoryFindAllResult>;
 }

--- a/src/interfaces/repository_interfaces/ICategoryRepository.ts
+++ b/src/interfaces/repository_interfaces/ICategoryRepository.ts
@@ -2,6 +2,7 @@ import { IBaseRepository } from './IBaseRepository';
 import { ICategory, ICategoryRequestPopulated } from '../../types/entities/category.entity';
 import { CategoryStatus } from '../../shared/constants/constants';
 import { CategoryFilters, CategoryFindAllResult } from '../../types/db';
+import { ReviewRequestDTO } from '../../types/dtos/admin/request.dtos';
 
 export interface ICategoryRepository extends IBaseRepository<ICategory> {
   findByName(name: string): Promise<ICategory | null>;
@@ -12,4 +13,5 @@ export interface ICategoryRepository extends IBaseRepository<ICategory> {
     page: number,
     limit: number,
   ): Promise<{ requests: ICategoryRequestPopulated[]; total: number }>;
+  reviewRequest(id: string, data: ReviewRequestDTO): Promise<ICategory | null>;
 }

--- a/src/interfaces/repository_interfaces/ICategoryRepository.ts
+++ b/src/interfaces/repository_interfaces/ICategoryRepository.ts
@@ -1,0 +1,5 @@
+import { IBaseRepository } from './IBaseRepository';
+import { ICategory } from '../../types/entities/category.entity';
+
+
+export interface ICategoryRepository extends IBaseRepository<ICategory> {}

--- a/src/interfaces/repository_interfaces/ICategoryRepository.ts
+++ b/src/interfaces/repository_interfaces/ICategoryRepository.ts
@@ -12,6 +12,13 @@ export interface ICategoryRepository extends IBaseRepository<ICategory> {
   findPendingRequests(
     page: number,
     limit: number,
+    search?: string,
   ): Promise<{ requests: ICategoryRequestPopulated[]; total: number }>;
   reviewRequest(id: string, data: ReviewRequestDTO): Promise<ICategory | null>;
+  findReviewedRequest(
+    page: number,
+    limit: number,
+    search?: string,
+    selectedFilter?: string,
+  ): Promise<{ requests: ICategoryRequestPopulated[]; total: number }>;
 }

--- a/src/interfaces/repository_interfaces/ICategoryRepository.ts
+++ b/src/interfaces/repository_interfaces/ICategoryRepository.ts
@@ -1,5 +1,7 @@
 import { IBaseRepository } from './IBaseRepository';
 import { ICategory } from '../../types/entities/category.entity';
 
-
-export interface ICategoryRepository extends IBaseRepository<ICategory> {}
+export interface ICategoryRepository extends IBaseRepository<ICategory> {
+  findByName(name: string): Promise<ICategory | null>;
+  findBySlug(slug: string, excludeId?: string): Promise<ICategory | null>;
+}

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -1,7 +1,5 @@
-import { ICategoryRequestDTO } from ".../../types/dtos/admin/request.dtos";
+import { ICreateCategoryInputDTO } from '.../../types/dtos/admin/request.dtos';
 
 export interface IAdminCategoryService {
-  
+  createCategory(adminId: string, categoryData: ICreateCategoryInputDTO): Promise<void>;
 }
-
-

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -1,5 +1,9 @@
-import { ICreateCategoryInputDTO } from '.../../types/dtos/admin/request.dtos';
+import {
+  ICreateCategoryInputDTO,
+  IUpdateCategoryInputDTO,
+} from '.../../types/dtos/admin/request.dtos';
 
 export interface IAdminCategoryService {
   createCategory(adminId: string, categoryData: ICreateCategoryInputDTO): Promise<void>;
+  updateCategory(adminId: string, id: string, data: IUpdateCategoryInputDTO): Promise<void>;
 }

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -6,12 +6,19 @@ import {
   PaginatedCategoryResponse,
   PaginatedData,
 } from '../../../types/common/IPaginationResponse';
-import { CategoryFilters } from 'types/db';
-import { CategoryResponseDTO } from 'types/dtos/admin/response.dtos';
+import { CategoryFilters } from '../../../types/db';
+import {
+  CategoryRequestResponseDTO,
+  CategoryResponseDTO,
+} from '../../../types/dtos/admin/response.dtos';
 
 export interface IAdminCategoryService {
   createCategory(adminId: string, categoryData: ICreateCategoryInputDTO): Promise<void>;
   updateCategory(adminId: string, id: string, data: IUpdateCategoryInputDTO): Promise<void>;
   toggleCategoryStatus(id: string): Promise<boolean>;
   getAllCategories(filters: CategoryFilters): Promise<PaginatedCategoryResponse>;
+  getPendingRequests(
+    page: number,
+    limit: number,
+  ): Promise<PaginatedData<CategoryRequestResponseDTO>>;
 }

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -6,4 +6,5 @@ import {
 export interface IAdminCategoryService {
   createCategory(adminId: string, categoryData: ICreateCategoryInputDTO): Promise<void>;
   updateCategory(adminId: string, id: string, data: IUpdateCategoryInputDTO): Promise<void>;
+  toggleCategoryStatus(id: string): Promise<boolean>;
 }

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -1,0 +1,8 @@
+import { ICategoryRequestDTO } from ".../../types/dtos/admin/request.dtos";
+
+
+export interface IAdminCategoryService {
+
+}
+
+

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -2,9 +2,16 @@ import {
   ICreateCategoryInputDTO,
   IUpdateCategoryInputDTO,
 } from '.../../types/dtos/admin/request.dtos';
+import {
+  PaginatedCategoryResponse,
+  PaginatedData,
+} from '../../../types/common/IPaginationResponse';
+import { CategoryFilters } from 'types/db';
+import { CategoryResponseDTO } from 'types/dtos/admin/response.dtos';
 
 export interface IAdminCategoryService {
   createCategory(adminId: string, categoryData: ICreateCategoryInputDTO): Promise<void>;
   updateCategory(adminId: string, id: string, data: IUpdateCategoryInputDTO): Promise<void>;
   toggleCategoryStatus(id: string): Promise<boolean>;
+  getAllCategories(filters: CategoryFilters): Promise<PaginatedCategoryResponse>;
 }

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -1,8 +1,7 @@
 import { ICategoryRequestDTO } from ".../../types/dtos/admin/request.dtos";
 
-
 export interface IAdminCategoryService {
-
+  
 }
 
 

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -21,4 +21,10 @@ export interface IAdminCategoryService {
     page: number,
     limit: number,
   ): Promise<PaginatedData<CategoryRequestResponseDTO>>;
+  reviewCategoryRequest(adminId: string, id: string, data: ReviewInput): Promise<void>;
+}
+
+export interface ReviewInput {
+  action: 'approve' | 'reject';
+  rejectionReason?: string;
 }

--- a/src/interfaces/service_interfaces/admin/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/admin/ICategoryService.ts
@@ -9,6 +9,7 @@ import {
 import { CategoryFilters } from '../../../types/db';
 import {
   CategoryRequestResponseDTO,
+  CategoryRequestReviewedResponseDTO,
   CategoryResponseDTO,
 } from '../../../types/dtos/admin/response.dtos';
 
@@ -20,8 +21,15 @@ export interface IAdminCategoryService {
   getPendingRequests(
     page: number,
     limit: number,
+    search?: string,
   ): Promise<PaginatedData<CategoryRequestResponseDTO>>;
   reviewCategoryRequest(adminId: string, id: string, data: ReviewInput): Promise<void>;
+  getReviewedRequests(
+    page: number,
+    limit: number,
+    search?: string,
+    selectedFilter?: string,
+  ): Promise<PaginatedData<CategoryRequestReviewedResponseDTO>>;
 }
 
 export interface ReviewInput {

--- a/src/middlewares/validate.dto.middleware.ts
+++ b/src/middlewares/validate.dto.middleware.ts
@@ -15,7 +15,7 @@ export const validateDTO =
 
       if (parsed.body) req.body = parsed.body;
       if (parsed.params) req.params = parsed.params;
-      if (parsed.query) req.query = parsed.query;
+      if (parsed.query) Object.assign(req.query, parsed.query);
 
       next();
     } catch (error) {

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,38 +1,84 @@
-import { ICategory } from "types/entities/category.entity";
+import { ICategory } from "../types/entities/category.entity";
 import mongoose, { Schema, Types } from "mongoose";
+import { CATEGORY_STATUS } from "../shared/constants/constants";
+import { generateSlug } from "../shared/utils/slug.generator.helper";
 
-const categorySchema = new Schema<ICategory>(
+const CategorySchema = new Schema<ICategory>(
   {
     name: {
-      type: String,
-      required: true,
-      trim: true,
+      type:      String,
+      required:  [true, 'Category name is required'],
+      trim:      true,
+    },
+
+    slug: {
+      type:     String,
+      unique:   true,   
+      trim:     true,
       lowercase: true,
     },
-    icon: {
-    key: String,
-    fieldName: String,
-    },
+
     description: {
-      type: String,
-      trim: true,
+      type:      String,
+      trim:      true,
+      default:   null,
     },
+
+    icon: {
+      type: String,  
+      trim:    true,
+      default: null,
+    },
+
     isActive: {
-      type: Boolean,
-      default: true,
-      required: true,
+      type:    Boolean,
+      default: false,    
     },
-    createdBy: {
-      type: Schema.Types.ObjectId,
-      ref: "User",
+
+    status: {
+      type:     String,
+      enum:     Object.values(CATEGORY_STATUS),
       required: true,
+      default:  CATEGORY_STATUS.PENDING,
+    },
+
+    createdBy: {
+      type:    Schema.Types.ObjectId,
+      ref:     'User',
+      default: null,
+    },
+
+    requestedBy: {
+      type:    Schema.Types.ObjectId,
+      ref:     'User',
+      default: null,
+    },
+
+    rejectionReason: {
+      type:      String,
+      trim:      true,
+      default:   null,
     },
   },
-  { timestamps: true }
-);
+  {
+    timestamps: true,  
+    versionKey: false,
+  }
+)
 
-categorySchema.index({ name: 1 }, { unique: true });
-categorySchema.index({ isActive: 1, name: 1 });
+CategorySchema.index({ slug: 1 })
+CategorySchema.index({ name: 1 }, { unique: true });
+CategorySchema.index({ status: 1, isActive: 1 })
+CategorySchema.index({ requestedBy: 1, status: 1 })
 
-export const CategoryModel = mongoose.model<ICategory>("Category", categorySchema);
+// ─── Pre-Save Hook — Auto-generate slug from name ────────────────
+// Runs every time a new document is saved
+CategorySchema.pre('save', function (next) {
+    if (this.isNew || this.isModified('name')) {
+        this.slug = generateSlug(this.name)
+    }
+    next()
+});
+
+export const CategoryModel = mongoose.model<ICategory>("Category", CategorySchema);
 

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,0 +1,38 @@
+import { ICategory } from "types/entities/category.entity";
+import mongoose, { Schema, Types } from "mongoose";
+
+const categorySchema = new Schema<ICategory>(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    icon: {
+    key: String,
+    fieldName: String,
+    },
+    description: {
+      type: String,
+      trim: true,
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+      required: true,
+    },
+    createdBy: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+categorySchema.index({ name: 1 }, { unique: true });
+categorySchema.index({ isActive: 1, name: 1 });
+
+export const CategoryModel = mongoose.model<ICategory>("Category", categorySchema);
+

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -25,9 +25,9 @@ const CategorySchema = new Schema<ICategory>(
     },
 
     icon: {
-       key: {
-         type: String,
-         trim: true,
+      key: {
+        type: String,
+        trim: true,
       },
     },
 
@@ -66,7 +66,6 @@ const CategorySchema = new Schema<ICategory>(
     versionKey: false,
   },
 );
-
 
 CategorySchema.index({ name: 1 }, { unique: true });
 CategorySchema.index({ status: 1, isActive: 1 });

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -60,6 +60,16 @@ const CategorySchema = new Schema<ICategory>(
       trim: true,
       default: null,
     },
+    vendorNote: {
+      type: String,
+      trim: true,
+      default: null,
+    },
+    adminNote: {
+      type: String,
+      trim: true,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,84 +1,84 @@
-import { ICategory } from "../types/entities/category.entity";
-import mongoose, { Schema, Types } from "mongoose";
-import { CATEGORY_STATUS } from "../shared/constants/constants";
-import { generateSlug } from "../shared/utils/slug.generator.helper";
+import { ICategory } from '../types/entities/category.entity';
+import mongoose, { Schema, Types } from 'mongoose';
+import { CATEGORY_STATUS } from '../shared/constants/constants';
+import { generateSlug } from '../shared/utils/slug.generator.helper';
 
 const CategorySchema = new Schema<ICategory>(
   {
     name: {
-      type:      String,
-      required:  [true, 'Category name is required'],
-      trim:      true,
+      type: String,
+      required: [true, 'Category name is required'],
+      trim: true,
     },
 
     slug: {
-      type:     String,
-      unique:   true,   
-      trim:     true,
+      type: String,
+      unique: true,
+      trim: true,
       lowercase: true,
     },
 
     description: {
-      type:      String,
-      trim:      true,
-      default:   null,
-    },
-
-    icon: {
-      type: String,  
-      trim:    true,
+      type: String,
+      trim: true,
       default: null,
     },
 
+    icon: {
+       key: {
+         type: String,
+         trim: true,
+      },
+    },
+
     isActive: {
-      type:    Boolean,
-      default: false,    
+      type: Boolean,
+      default: false,
     },
 
     status: {
-      type:     String,
-      enum:     Object.values(CATEGORY_STATUS),
+      type: String,
+      enum: Object.values(CATEGORY_STATUS),
       required: true,
-      default:  CATEGORY_STATUS.PENDING,
+      default: CATEGORY_STATUS.PENDING,
     },
 
     createdBy: {
-      type:    Schema.Types.ObjectId,
-      ref:     'User',
+      type: Schema.Types.ObjectId,
+      ref: 'User',
       default: null,
     },
 
     requestedBy: {
-      type:    Schema.Types.ObjectId,
-      ref:     'User',
+      type: Schema.Types.ObjectId,
+      ref: 'User',
       default: null,
     },
 
     rejectionReason: {
-      type:      String,
-      trim:      true,
-      default:   null,
+      type: String,
+      trim: true,
+      default: null,
     },
   },
   {
-    timestamps: true,  
+    timestamps: true,
     versionKey: false,
-  }
-)
+  },
+);
 
-CategorySchema.index({ slug: 1 })
+
 CategorySchema.index({ name: 1 }, { unique: true });
-CategorySchema.index({ status: 1, isActive: 1 })
-CategorySchema.index({ requestedBy: 1, status: 1 })
+CategorySchema.index({ status: 1, isActive: 1 });
+CategorySchema.index({ requestedBy: 1, status: 1 });
 
 // ─── Pre-Save Hook — Auto-generate slug from name ────────────────
 // Runs every time a new document is saved
 CategorySchema.pre('save', function (next) {
-    if (this.isNew || this.isModified('name')) {
-        this.slug = generateSlug(this.name)
-    }
-    next()
+  if (this.isNew || this.isModified('name')) {
+    this.slug = generateSlug(this.name);
+  }
+  next();
 });
 
-export const CategoryModel = mongoose.model<ICategory>("Category", CategorySchema);
-
+export const CategoryModel = mongoose.model<ICategory>('Category', CategorySchema);

--- a/src/models/package.model.ts
+++ b/src/models/package.model.ts
@@ -8,7 +8,7 @@ const FileSchema = new Schema(
   {
     key: { type: String },
   },
-  { _id: false }
+  { _id: false },
 );
 
 const activitySchema = new Schema(
@@ -47,7 +47,7 @@ const packageSchema = new Schema<IBasePackageEntity>(
     },
 
     title: { type: String, trim: true },
-    
+
     location: { type: String, trim: true },
 
     pickupLocation: { type: String, trim: true },

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -4,6 +4,7 @@ import { ICategory } from '../types/entities/category.entity';
 import { CategoryModel } from '../models/category.model';
 import { ICategoryRepository } from '../interfaces/repository_interfaces/ICategoryRepository';
 import mongoose from 'mongoose';
+import { CategoryStatus } from 'shared/constants/constants';
 
 @injectable()
 export class CategoryRepository extends BaseRepository<ICategory> implements ICategoryRepository {
@@ -19,5 +20,17 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
 
   async findBySlug(slug: string): Promise<ICategory | null> {
     return CategoryModel.findOne({ slug: slug.toLowerCase() }).lean() as Promise<ICategory | null>;
+  }
+
+  async toggleStatus(
+    id: string,
+    isActive: boolean,
+    status: CategoryStatus,
+  ): Promise<ICategory | null> {
+    return CategoryModel.findByIdAndUpdate(
+      id,
+      { $set: { isActive, status } },
+      { new: true },
+    ).lean() as Promise<ICategory | null>;
   }
 }

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -21,7 +21,7 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
   async findByName(name: string): Promise<ICategory | null> {
     return this.findOne({
       name: { $regex: new RegExp(`^${name.trim()}$`, 'i') },
-    })as Promise<ICategory | null>;
+    }) as Promise<ICategory | null>;
   }
 
   async findBySlug(slug: string): Promise<ICategory | null> {
@@ -158,12 +158,20 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
   async findPendingRequests(
     page: number,
     limit: number,
+    search?: string,
   ): Promise<{ requests: ICategoryRequestPopulated[]; total: number }> {
-    const query = { status: CATEGORY_STATUS.PENDING };
+    const query: mongoose.FilterQuery<ICategory> = {
+      status: CATEGORY_STATUS.PENDING,
+    };
+
+    if (search?.trim()) {
+      query.name = { $regex: new RegExp(search.trim(), 'i') };
+    }
     const skip = (page - 1) * limit;
 
     const [requests, total] = await Promise.all([
-      this.model.find(query)
+      this.model
+        .find(query)
         .populate<{ requestedBy: { _id: string; name: string; email: string } }>(
           'requestedBy',
           'name email',
@@ -196,5 +204,40 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
       { $set: updateData },
       { new: true },
     ) as Promise<ICategory | null>;
+  }
+
+  async findReviewedRequest(
+    page: number,
+    limit: number,
+    search?: string,
+    selectedFilter?: string,
+  ): Promise<{ requests: ICategoryRequestPopulated[]; total: number }> {
+    const query: mongoose.FilterQuery<ICategory> = {
+      status: selectedFilter
+        ? selectedFilter
+        : { $in: [CATEGORY_STATUS.REJECTED, CATEGORY_STATUS.ACTIVE] },
+      requestedBy: { $ne: null },
+    };
+
+    if (search?.trim()) {
+      query.name = { $regex: new RegExp(search.trim(), 'i') };
+    }
+
+    const skip = (page - 1) * limit;
+
+    const [requests, total] = await Promise.all([
+      this.model
+        .find(query)
+        .populate<{
+          requestedBy: { _id: string; name: string; email: string };
+        }>('requestedBy', 'name email')
+        .sort({ updatedAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean<ICategoryRequestPopulated[]>(),
+      this.model.countDocuments(query),
+    ]);
+
+    return { requests, total };
   }
 }

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -1,0 +1,12 @@
+import { injectable } from 'tsyringe';
+import { BaseRepository } from './base.repository';
+import { ICategory } from '../types/entities/category.entity';
+import { CategoryModel } from '../models/category.model';
+import { ICategoryRepository } from '../interfaces/repository_interfaces/ICategoryRepository';
+
+@injectable()
+export class CategoryRepository extends BaseRepository<ICategory> implements ICategoryRepository{
+  constructor() {
+    super(CategoryModel);
+  }
+}

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -4,7 +4,8 @@ import { ICategory } from '../types/entities/category.entity';
 import { CategoryModel } from '../models/category.model';
 import { ICategoryRepository } from '../interfaces/repository_interfaces/ICategoryRepository';
 import mongoose from 'mongoose';
-import { CategoryStatus } from 'shared/constants/constants';
+import { CATEGORY_STATUS, CategoryStatus } from '../shared/constants/constants';
+import { CategoryFilters, CategoryFindAllResult } from '../types/db';
 
 @injectable()
 export class CategoryRepository extends BaseRepository<ICategory> implements ICategoryRepository {
@@ -32,5 +33,120 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
       { $set: { isActive, status } },
       { new: true },
     ).lean() as Promise<ICategory | null>;
+  }
+
+  async findAllCategory(filters: CategoryFilters): Promise<CategoryFindAllResult> {
+    const searchMatch: mongoose.FilterQuery<ICategory> = {};
+
+    if (filters.search?.trim()) {
+      searchMatch.name = { $regex: new RegExp(filters.search.trim(), 'i') };
+    }
+
+    let isActiveFilter: mongoose.FilterQuery<ICategory> = {};
+    if (!filters?.status) {
+      isActiveFilter.status = [CATEGORY_STATUS.ACTIVE, CATEGORY_STATUS.INACTIVE];
+    } else {
+      isActiveFilter.status = [filters.status];
+    }
+
+    const skip = (filters.page - 1) * filters.limit;
+
+    const [result] = await CategoryModel.aggregate([
+      { $match: searchMatch },
+
+      {
+        $facet: {
+          // Branch 1: paginated list — only approved + dropdown filter
+          categories: [
+            {
+              $match: {
+                status: { $in: [...isActiveFilter.status] },
+              },
+            },
+            { $sort: { createdAt: -1 } },
+            { $skip: skip },
+            { $limit: filters.limit },
+          ],
+
+          // Branch 2: total for pagination — respects dropdown filter
+          totalCount: [
+            {
+              $match: {
+                status: { $in: [...isActiveFilter.status] },
+              },
+            },
+            { $count: 'count' },
+          ],
+
+          // Branch 3: global stats — sees ALL statuses, unaffected by dropdown
+          stats: [
+            {
+              $group: {
+                _id: null,
+                total: {
+                  $sum: {
+                    $cond: [
+                      { $in: ['$status', [CATEGORY_STATUS.ACTIVE, CATEGORY_STATUS.INACTIVE]] },
+                      1,
+                      0,
+                    ],
+                  },
+                },
+                active: {
+                  $sum: {
+                    $cond: [
+                      {
+                        $and: [
+                          { $eq: ['$status', CATEGORY_STATUS.ACTIVE] },
+                          { $eq: ['$isActive', true] },
+                        ],
+                      },
+                      1,
+                      0,
+                    ],
+                  },
+                },
+                inactive: {
+                  $sum: {
+                    $cond: [
+                      {
+                        $and: [
+                          { $eq: ['$status', CATEGORY_STATUS.INACTIVE] },
+                          { $eq: ['$isActive', false] },
+                        ],
+                      },
+                      1,
+                      0,
+                    ],
+                  },
+                },
+                pendingApproval: {
+                  $sum: { $cond: [{ $eq: ['$status', CATEGORY_STATUS.PENDING] }, 1, 0] },
+                },
+              },
+            },
+          ],
+        },
+      },
+
+      {
+        $project: {
+          categories: 1,
+          total: { $ifNull: [{ $arrayElemAt: ['$totalCount.count', 0] }, 0] },
+          stats: {
+            total: { $ifNull: [{ $arrayElemAt: ['$stats.total', 0] }, 0] },
+            active: { $ifNull: [{ $arrayElemAt: ['$stats.active', 0] }, 0] },
+            inactive: { $ifNull: [{ $arrayElemAt: ['$stats.inactive', 0] }, 0] },
+            pendingApproval: { $ifNull: [{ $arrayElemAt: ['$stats.pendingApproval', 0] }, 0] },
+          },
+        },
+      },
+    ]);
+
+    return {
+      categories: result.categories as ICategory[],
+      total: result.total,
+      stats: result.stats,
+    };
   }
 }

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -19,13 +19,13 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
   }
 
   async findByName(name: string): Promise<ICategory | null> {
-    return CategoryModel.findOne({
+    return this.findOne({
       name: { $regex: new RegExp(`^${name.trim()}$`, 'i') },
-    }).lean() as Promise<ICategory | null>;
+    })as Promise<ICategory | null>;
   }
 
   async findBySlug(slug: string): Promise<ICategory | null> {
-    return CategoryModel.findOne({ slug: slug.toLowerCase() }).lean() as Promise<ICategory | null>;
+    return this.findOne({ slug: slug.toLowerCase() }) as Promise<ICategory | null>;
   }
 
   async toggleStatus(
@@ -33,11 +33,11 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
     isActive: boolean,
     status: CategoryStatus,
   ): Promise<ICategory | null> {
-    return CategoryModel.findByIdAndUpdate(
+    return this.findByIdAndUpdate(
       id,
       { $set: { isActive, status } },
       { new: true },
-    ).lean() as Promise<ICategory | null>;
+    ) as Promise<ICategory | null>;
   }
 
   async findAllCategory(filters: CategoryFilters): Promise<CategoryFindAllResult> {
@@ -56,7 +56,7 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
 
     const skip = (filters.page - 1) * filters.limit;
 
-    const [result] = await CategoryModel.aggregate([
+    const [result] = await this.model.aggregate([
       { $match: searchMatch },
 
       {
@@ -163,7 +163,7 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
     const skip = (page - 1) * limit;
 
     const [requests, total] = await Promise.all([
-      CategoryModel.find(query)
+      this.model.find(query)
         .populate<{ requestedBy: { _id: string; name: string; email: string } }>(
           'requestedBy',
           'name email',

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -1,6 +1,6 @@
 import { injectable } from 'tsyringe';
 import { BaseRepository } from './base.repository';
-import { ICategory } from '../types/entities/category.entity';
+import { ICategory, ICategoryRequestPopulated } from '../types/entities/category.entity';
 import { CategoryModel } from '../models/category.model';
 import { ICategoryRepository } from '../interfaces/repository_interfaces/ICategoryRepository';
 import mongoose from 'mongoose';
@@ -148,5 +148,28 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
       total: result.total,
       stats: result.stats,
     };
+  }
+
+  async findPendingRequests(
+    page: number,
+    limit: number,
+  ): Promise<{ requests: ICategoryRequestPopulated[]; total: number }> {
+    const query = { status: CATEGORY_STATUS.PENDING };
+    const skip = (page - 1) * limit;
+
+    const [requests, total] = await Promise.all([
+      CategoryModel.find(query)
+        .populate<{ requestedBy: { _id: string; name: string; email: string } }>(
+          'requestedBy',
+          'name email',
+        ) // vendor info
+        .sort({ createdAt: 1 })
+        .skip(skip)
+        .limit(limit)
+        .lean<ICategoryRequestPopulated[]>(),
+      CategoryModel.countDocuments(query),
+    ]);
+
+    return { requests, total };
   }
 }

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -3,10 +3,21 @@ import { BaseRepository } from './base.repository';
 import { ICategory } from '../types/entities/category.entity';
 import { CategoryModel } from '../models/category.model';
 import { ICategoryRepository } from '../interfaces/repository_interfaces/ICategoryRepository';
+import mongoose from 'mongoose';
 
 @injectable()
-export class CategoryRepository extends BaseRepository<ICategory> implements ICategoryRepository{
+export class CategoryRepository extends BaseRepository<ICategory> implements ICategoryRepository {
   constructor() {
     super(CategoryModel);
+  }
+
+  async findByName(name: string): Promise<ICategory | null> {
+    return CategoryModel.findOne({
+      name: { $regex: new RegExp(`^${name.trim()}$`, 'i') },
+    }).lean() as Promise<ICategory | null>;
+  }
+
+  async findBySlug(slug: string): Promise<ICategory | null> {
+    return CategoryModel.findOne({ slug: slug.toLowerCase() }).lean() as Promise<ICategory | null>;
   }
 }

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -4,8 +4,13 @@ import { ICategory, ICategoryRequestPopulated } from '../types/entities/category
 import { CategoryModel } from '../models/category.model';
 import { ICategoryRepository } from '../interfaces/repository_interfaces/ICategoryRepository';
 import mongoose from 'mongoose';
-import { CATEGORY_STATUS, CategoryStatus } from '../shared/constants/constants';
+import {
+  APPROVE_REJECT_ACTIONS,
+  CATEGORY_STATUS,
+  CategoryStatus,
+} from '../shared/constants/constants';
 import { CategoryFilters, CategoryFindAllResult } from '../types/db';
+import { ReviewRequestDTO } from 'types/dtos/admin/request.dtos';
 
 @injectable()
 export class CategoryRepository extends BaseRepository<ICategory> implements ICategoryRepository {
@@ -171,5 +176,25 @@ export class CategoryRepository extends BaseRepository<ICategory> implements ICa
     ]);
 
     return { requests, total };
+  }
+
+  async reviewRequest(id: string, data: ReviewRequestDTO): Promise<ICategory | null> {
+    const updateData: Partial<ICategory> = {
+      status: data.status as CategoryStatus,
+      isActive: data.isActive,
+      createdBy: new mongoose.Types.ObjectId(data.adminId), // admin who reviewed
+    };
+
+    if (data.status === APPROVE_REJECT_ACTIONS.REJECT && data.rejectionReason) {
+      updateData.rejectionReason = data.rejectionReason;
+    } else {
+      updateData.slug = data.slug;
+    }
+
+    return this.findByIdAndUpdate(
+      id,
+      { $set: updateData },
+      { new: true },
+    ) as Promise<ICategory | null>;
   }
 }

--- a/src/routes/admin/admin.routes.ts
+++ b/src/routes/admin/admin.routes.ts
@@ -9,7 +9,10 @@ import { validateDTO } from '../../middlewares/validate.dto.middleware';
 import { BlockOrUnblockUserSchema } from '../../types/dtos/admin/user/request.dtos';
 import { UpdateVendorVerificationSchema } from '../../types/dtos/admin/vendor/request.dtos';
 import { IAdminCategoryController } from '../../interfaces/controller_interfaces/admin/IAdminCategoryController';
-import { createCategorySchema , updateCategorySchema} from '../../validators/admin/category.validation';
+import {
+  createCategorySchema,
+  updateCategorySchema,
+} from '../../validators/admin/category.validation';
 @injectable()
 export class AdminRoutes extends BaseRoute {
   constructor(
@@ -68,18 +71,25 @@ export class AdminRoutes extends BaseRoute {
     // =================Category management===================
     this._router.post(
       '/category',
-      // isAuthenticated,
-      // authorize([USER_ROLES.ADMIN]),
+      isAuthenticated,
+      authorize([USER_ROLES.ADMIN]),
       validateDTO(createCategorySchema),
       this._adminCategoryController.createCategory.bind(this._adminCategoryController),
     );
 
-      this._router.put(
+    this._router.put(
       '/category/:id',
-      // isAuthenticated,
-      // authorize([USER_ROLES.ADMIN]),
+      isAuthenticated,
+      authorize([USER_ROLES.ADMIN]),
       validateDTO(updateCategorySchema),
       this._adminCategoryController.updateCategory.bind(this._adminCategoryController),
+    );
+
+    this._router.patch(
+      '/category/:id/toggle',
+      isAuthenticated,
+      authorize([USER_ROLES.ADMIN]),
+      this._adminCategoryController.toggleCategoryStatus.bind(this._adminCategoryController),
     );
   }
 }

--- a/src/routes/admin/admin.routes.ts
+++ b/src/routes/admin/admin.routes.ts
@@ -11,6 +11,7 @@ import { UpdateVendorVerificationSchema } from '../../types/dtos/admin/vendor/re
 import { IAdminCategoryController } from '../../interfaces/controller_interfaces/admin/IAdminCategoryController';
 import {
   createCategorySchema,
+  reviewCategorySchema,
   updateCategorySchema,
 } from '../../validators/admin/category.validation';
 @injectable()
@@ -92,11 +93,12 @@ export class AdminRoutes extends BaseRoute {
       this._adminCategoryController.toggleCategoryStatus.bind(this._adminCategoryController),
     );
 
-    this._router.get(
-      '/category/requests',
+    this._router.patch(
+      '/category/requests/:id/review',
       isAuthenticated,
       authorize([USER_ROLES.ADMIN]),
-      this._adminCategoryController.getPendingRequest.bind(this._adminCategoryController),
+      validateDTO(reviewCategorySchema),
+      this._adminCategoryController.reviewCategoryRequest.bind(this._adminCategoryController),
     );
   }
 }

--- a/src/routes/admin/admin.routes.ts
+++ b/src/routes/admin/admin.routes.ts
@@ -93,10 +93,10 @@ export class AdminRoutes extends BaseRoute {
     );
 
     this._router.get(
-      '/category',
-      // isAuthenticated,
-      // authorize([USER_ROLES.ADMIN]),
-      this._adminCategoryController.getAllCategories.bind(this._adminCategoryController),
+      '/category/requests',
+      isAuthenticated,
+      authorize([USER_ROLES.ADMIN]),
+      this._adminCategoryController.getPendingRequest.bind(this._adminCategoryController),
     );
   }
 }

--- a/src/routes/admin/admin.routes.ts
+++ b/src/routes/admin/admin.routes.ts
@@ -12,6 +12,7 @@ import { IAdminCategoryController } from '../../interfaces/controller_interfaces
 import {
   createCategorySchema,
   reviewCategorySchema,
+  reviewedCategorySchema,
   updateCategorySchema,
 } from '../../validators/admin/category.validation';
 @injectable()
@@ -93,12 +94,34 @@ export class AdminRoutes extends BaseRoute {
       this._adminCategoryController.toggleCategoryStatus.bind(this._adminCategoryController),
     );
 
+    this._router.get(
+      '/category',
+      isAuthenticated,
+      authorize([USER_ROLES.ADMIN]),
+      this._adminCategoryController.getAllCategories.bind(this._adminCategoryController),
+    );
+
+    this._router.get(
+      '/category/requests',
+      isAuthenticated,
+      authorize([USER_ROLES.ADMIN]),
+      this._adminCategoryController.getPendingRequest.bind(this._adminCategoryController),
+    );
+
     this._router.patch(
       '/category/requests/:id/review',
       isAuthenticated,
       authorize([USER_ROLES.ADMIN]),
       validateDTO(reviewCategorySchema),
       this._adminCategoryController.reviewCategoryRequest.bind(this._adminCategoryController),
+    );
+
+    this._router.get(
+      '/category/requests/reviewed',
+      isAuthenticated,
+      authorize([USER_ROLES.ADMIN]),
+      validateDTO(reviewedCategorySchema),
+      this._adminCategoryController.getReviwedRequest.bind(this._adminCategoryController),
     );
   }
 }

--- a/src/routes/admin/admin.routes.ts
+++ b/src/routes/admin/admin.routes.ts
@@ -91,5 +91,12 @@ export class AdminRoutes extends BaseRoute {
       authorize([USER_ROLES.ADMIN]),
       this._adminCategoryController.toggleCategoryStatus.bind(this._adminCategoryController),
     );
+
+    this._router.get(
+      '/category',
+      // isAuthenticated,
+      // authorize([USER_ROLES.ADMIN]),
+      this._adminCategoryController.getAllCategories.bind(this._adminCategoryController),
+    );
   }
 }

--- a/src/routes/admin/admin.routes.ts
+++ b/src/routes/admin/admin.routes.ts
@@ -9,7 +9,7 @@ import { validateDTO } from '../../middlewares/validate.dto.middleware';
 import { BlockOrUnblockUserSchema } from '../../types/dtos/admin/user/request.dtos';
 import { UpdateVendorVerificationSchema } from '../../types/dtos/admin/vendor/request.dtos';
 import { IAdminCategoryController } from '../../interfaces/controller_interfaces/admin/IAdminCategoryController';
-import { createCategorySchema } from '../../validators/admin/category.validation';
+import { createCategorySchema , updateCategorySchema} from '../../validators/admin/category.validation';
 @injectable()
 export class AdminRoutes extends BaseRoute {
   constructor(
@@ -68,10 +68,18 @@ export class AdminRoutes extends BaseRoute {
     // =================Category management===================
     this._router.post(
       '/category',
-      isAuthenticated,
-      authorize([USER_ROLES.ADMIN]),
+      // isAuthenticated,
+      // authorize([USER_ROLES.ADMIN]),
       validateDTO(createCategorySchema),
       this._adminCategoryController.createCategory.bind(this._adminCategoryController),
+    );
+
+      this._router.put(
+      '/category/:id',
+      // isAuthenticated,
+      // authorize([USER_ROLES.ADMIN]),
+      validateDTO(updateCategorySchema),
+      this._adminCategoryController.updateCategory.bind(this._adminCategoryController),
     );
   }
 }

--- a/src/routes/admin/admin.routes.ts
+++ b/src/routes/admin/admin.routes.ts
@@ -8,6 +8,8 @@ import { USER_ROLES } from '../../shared/constants/roles';
 import { validateDTO } from '../../middlewares/validate.dto.middleware';
 import { BlockOrUnblockUserSchema } from '../../types/dtos/admin/user/request.dtos';
 import { UpdateVendorVerificationSchema } from '../../types/dtos/admin/vendor/request.dtos';
+import { IAdminCategoryController } from '../../interfaces/controller_interfaces/admin/IAdminCategoryController';
+import { createCategorySchema } from '../../validators/admin/category.validation';
 @injectable()
 export class AdminRoutes extends BaseRoute {
   constructor(
@@ -15,6 +17,8 @@ export class AdminRoutes extends BaseRoute {
     private _adminUserContoller: IAdminUserController,
     @inject('IAdminVendorController')
     private _adminVendorController: IAdminVendorController,
+    @inject('IAdminCategoryController')
+    private _adminCategoryController: IAdminCategoryController,
   ) {
     super();
     this.initializeRoutes();
@@ -31,10 +35,9 @@ export class AdminRoutes extends BaseRoute {
 
     this._router.patch(
       '/users/:userId/status',
-      validateDTO(BlockOrUnblockUserSchema),
       isAuthenticated,
       authorize([USER_ROLES.ADMIN]),
-
+      validateDTO(BlockOrUnblockUserSchema),
       this._adminUserContoller.blockOrUnblockUser.bind(this._adminUserContoller),
     );
 
@@ -49,9 +52,9 @@ export class AdminRoutes extends BaseRoute {
 
     this._router.patch(
       '/update-vendor-verification/:vendorId',
-      validateDTO(UpdateVendorVerificationSchema),
       isAuthenticated,
       authorize([USER_ROLES.ADMIN]),
+      validateDTO(UpdateVendorVerificationSchema),
       this._adminVendorController.updateVendorVerification.bind(this._adminVendorController),
     );
 
@@ -60,6 +63,15 @@ export class AdminRoutes extends BaseRoute {
       isAuthenticated,
       authorize([USER_ROLES.ADMIN]),
       this._adminVendorController.getVendors.bind(this._adminVendorController),
+    );
+
+    // =================Category management===================
+    this._router.post(
+      '/category',
+      isAuthenticated,
+      authorize([USER_ROLES.ADMIN]),
+      validateDTO(createCategorySchema),
+      this._adminCategoryController.createCategory.bind(this._adminCategoryController),
     );
   }
 }

--- a/src/routes/vendor/vendor.routes.ts
+++ b/src/routes/vendor/vendor.routes.ts
@@ -58,12 +58,12 @@ export class VendorRoutes extends BaseRoute {
       this._vendorPackageController.createPackage.bind(this._vendorPackageController),
     );
 
-    this._router.put('/packages/:packageId',
+    this._router.put(
+      '/packages/:packageId',
       isAuthenticated,
       authorize([USER_ROLES.VENDOR]),
       validateDTO(PackageCreateUnionSchema),
       this._vendorPackageController.updatePackage.bind(this._vendorPackageController),
-
     );
 
     this._router.get(
@@ -81,5 +81,3 @@ export class VendorRoutes extends BaseRoute {
     );
   }
 }
-
-

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -13,8 +13,11 @@ import { ERROR_MESSAGES } from '../../shared/constants/messages';
 import { CATEGORY_STATUS, CategoryStatus } from '../../shared/constants/constants';
 import { PaginatedCategoryResponse, PaginatedData } from '../../types/common/IPaginationResponse';
 import { CategoryFilters } from '../../types/db';
-import { CategoryResponseDTO } from '../../types/dtos/admin/response.dtos';
-import { ICategory } from 'types/entities/category.entity';
+import {
+  CategoryRequestResponseDTO,
+  CategoryResponseDTO,
+} from '../../types/dtos/admin/response.dtos';
+import { ICategory, ICategoryRequestPopulated } from '../../types/entities/category.entity';
 
 @injectable()
 export class CategoryService implements IAdminCategoryService {
@@ -37,6 +40,25 @@ export class CategoryService implements IAdminCategoryService {
       rejectionReason: cat.rejectionReason ?? null,
       createdAt: cat.createdAt,
       updatedAt: cat.updatedAt,
+    };
+  }
+
+  private toRequestResponse(cat: ICategoryRequestPopulated): CategoryRequestResponseDTO {
+    return {
+      name: cat.name,
+      requested: cat.requestedBy
+        ? {
+            name: cat.requestedBy.name,
+            email: cat.requestedBy.email,
+          }
+        : null,
+      vendorNote: cat.vendorNote ?? null,
+      date: new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: '2-digit',
+        year: 'numeric',
+      }).format(cat.createdAt),
+      status: cat.status,
     };
   }
 
@@ -97,12 +119,12 @@ export class CategoryService implements IAdminCategoryService {
     return newIsActive;
   }
 
-    async getAllCategories(filters: CategoryFilters): Promise<PaginatedCategoryResponse> {
-      
+  async getAllCategories(filters: CategoryFilters): Promise<PaginatedCategoryResponse> {
     const invalidStatuses = new Set<CategoryStatus>([
       CATEGORY_STATUS.ACTIVE,
       CATEGORY_STATUS.INACTIVE,
     ]);
+
     if (filters.status && !invalidStatuses.has(filters.status)) {
       throw new AppError(`Filter by '${filters.status}' is not permitted`, HTTP_STATUS.BAD_REQUEST);
     }
@@ -116,6 +138,19 @@ export class CategoryService implements IAdminCategoryService {
       currentPage: filters.page,
       totalPages: Math.ceil(data.total / filters.limit),
       stats: data.stats,
+    };
+  }
+
+  async getPendingRequests(
+    page: number,
+    limit: number,
+  ): Promise<PaginatedData<CategoryRequestResponseDTO>> {
+    const { requests, total } = await this._categoryRepository.findPendingRequests(page, limit);
+    return {
+      data: requests.map(this.toRequestResponse.bind(this)),
+      totalDocs: total,
+      currentPage: page,
+      totalPages: Math.ceil(total / limit),
     };
   }
 }

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -23,6 +23,7 @@ import { CategoryFilters } from '../../types/db';
 import {
   CategoryRequestResponseDTO,
   CategoryResponseDTO,
+  CategoryRequestReviewedResponseDTO,
 } from '../../types/dtos/admin/response.dtos';
 import { ICategory, ICategoryRequestPopulated } from '../../types/entities/category.entity';
 
@@ -52,6 +53,7 @@ export class CategoryService implements IAdminCategoryService {
 
   private toRequestResponse(cat: ICategoryRequestPopulated): CategoryRequestResponseDTO {
     return {
+      id: cat._id.toString(),
       name: cat.name,
       requested: cat.requestedBy
         ? {
@@ -65,6 +67,28 @@ export class CategoryService implements IAdminCategoryService {
         day: '2-digit',
         year: 'numeric',
       }).format(cat.createdAt),
+      status: cat.status,
+    };
+  }
+
+  private toRequestReviwedResponse(
+    cat: ICategoryRequestPopulated,
+  ): CategoryRequestReviewedResponseDTO {
+    return {
+      id: cat._id.toString(),
+      name: cat.name,
+      requested: cat.requestedBy
+        ? {
+            name: cat.requestedBy.name,
+            email: cat.requestedBy.email,
+          }
+        : null,
+      adminNote: cat.adminNote ?? null,
+      updatedDate: new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: '2-digit',
+        year: 'numeric',
+      }).format(cat.updatedAt),
       status: cat.status,
     };
   }
@@ -151,8 +175,13 @@ export class CategoryService implements IAdminCategoryService {
   async getPendingRequests(
     page: number,
     limit: number,
+    search?: string,
   ): Promise<PaginatedData<CategoryRequestResponseDTO>> {
-    const { requests, total } = await this._categoryRepository.findPendingRequests(page, limit);
+    const { requests, total } = await this._categoryRepository.findPendingRequests(
+      page,
+      limit,
+      search,
+    );
     return {
       data: requests.map(this.toRequestResponse.bind(this)),
       totalDocs: total,
@@ -202,5 +231,25 @@ export class CategoryService implements IAdminCategoryService {
       adminId,
       rejectionReason: data.rejectionReason!.trim(),
     });
+  }
+
+  async getReviewedRequests(
+    page: number,
+    limit: number,
+    search?: string,
+    selectedFilter?: string,
+  ): Promise<PaginatedData<CategoryRequestReviewedResponseDTO>> {
+    const { requests, total } = await this._categoryRepository.findReviewedRequest(
+      page,
+      limit,
+      search,
+      selectedFilter,
+    );
+    return {
+      data: requests.map(this.toRequestReviwedResponse.bind(this)),
+      totalDocs: total,
+      currentPage: page,
+      totalPages: Math.ceil(total / limit),
+    };
   }
 }

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -1,0 +1,14 @@
+import { inject, injectable } from 'tsyringe';
+import { IAdminCategoryService } from '../../interfaces/service_interfaces/admin/ICategoryService';
+import { ICategoryRepository } from '../../interfaces/repository_interfaces/ICategoryRepository';
+
+@injectable()
+export class CategoryService implements IAdminCategoryService {
+    constructor(
+        @inject('ICategoryRepository')
+        private _categoryRepository: ICategoryRepository,
+    
+    ) { }
+    
+    
+}

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -31,9 +31,9 @@ export class CategoryService implements IAdminCategoryService {
 
     await this._categoryRepository.create({
       ...data,
-        slug,
-        isActive: true,
-      status:CATEGORY_STATUS.ACTIVE,
+      slug,
+      isActive: true,
+      status: CATEGORY_STATUS.ACTIVE,
       createdBy: adminObjectId,
     });
   }
@@ -54,5 +54,25 @@ export class CategoryService implements IAdminCategoryService {
     const updated = await this._categoryRepository.findByIdAndUpdate(id, data);
     if (!updated)
       throw new AppError(ERROR_MESSAGES.UNEXPECTED_SERVER_ERROR, HTTP_STATUS.INTERNAL_SERVER_ERROR);
+  }
+
+  async toggleCategoryStatus(id: string): Promise<boolean> {
+    const category = await this._categoryRepository.findById(id);
+    if (!category) {
+      throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
+    }
+
+    if (
+      category.status === CATEGORY_STATUS.PENDING ||
+      category.status === CATEGORY_STATUS.REJECTED
+    ) {
+      throw new AppError(ERROR_MESSAGES.CANNOT_TOGGLE, HTTP_STATUS.BAD_REQUEST);
+    }
+    const newIsActive = !category.isActive;
+    const newStatus = newIsActive ? CATEGORY_STATUS.ACTIVE : CATEGORY_STATUS.INACTIVE;
+
+    await this._categoryRepository.toggleStatus(id, newIsActive, newStatus);
+
+    return newIsActive;
   }
 }

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -10,5 +10,5 @@ export class CategoryService implements IAdminCategoryService {
     
     ) { }
     
-    
+
 }

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -10,7 +10,11 @@ import { HTTP_STATUS } from '../../shared/constants/http_status_code';
 import { generateSlug } from '../../shared/utils/slug.generator.helper';
 import { toObjectId } from '../../shared/utils/database/objectId.helper';
 import { ERROR_MESSAGES } from '../../shared/constants/messages';
-import { CATEGORY_STATUS } from '../../shared/constants/constants';
+import { CATEGORY_STATUS, CategoryStatus } from '../../shared/constants/constants';
+import { PaginatedCategoryResponse, PaginatedData } from '../../types/common/IPaginationResponse';
+import { CategoryFilters } from '../../types/db';
+import { CategoryResponseDTO } from '../../types/dtos/admin/response.dtos';
+import { ICategory } from 'types/entities/category.entity';
 
 @injectable()
 export class CategoryService implements IAdminCategoryService {
@@ -18,6 +22,23 @@ export class CategoryService implements IAdminCategoryService {
     @inject('ICategoryRepository')
     private _categoryRepository: ICategoryRepository,
   ) {}
+
+  private toResponse(cat: ICategory): CategoryResponseDTO {
+    return {
+      id: cat._id.toString(),
+      name: cat.name,
+      slug: cat.slug,
+      description: cat.description ?? null,
+      icon: cat.icon ?? null,
+      isActive: cat.isActive,
+      status: cat.status,
+      createdBy: cat.createdBy?.toString() ?? null,
+      requestedBy: cat.requestedBy?.toString() ?? null,
+      rejectionReason: cat.rejectionReason ?? null,
+      createdAt: cat.createdAt,
+      updatedAt: cat.updatedAt,
+    };
+  }
 
   async createCategory(adminId: string, data: ICreateCategoryInputDTO): Promise<void> {
     const adminObjectId = toObjectId(adminId);
@@ -74,5 +95,27 @@ export class CategoryService implements IAdminCategoryService {
     await this._categoryRepository.toggleStatus(id, newIsActive, newStatus);
 
     return newIsActive;
+  }
+
+    async getAllCategories(filters: CategoryFilters): Promise<PaginatedCategoryResponse> {
+      
+    const invalidStatuses = new Set<CategoryStatus>([
+      CATEGORY_STATUS.ACTIVE,
+      CATEGORY_STATUS.INACTIVE,
+    ]);
+    if (filters.status && !invalidStatuses.has(filters.status)) {
+      throw new AppError(`Filter by '${filters.status}' is not permitted`, HTTP_STATUS.BAD_REQUEST);
+    }
+    const data = await this._categoryRepository.findAllCategory({
+      ...filters,
+    });
+
+    return {
+      data: data.categories.map(this.toResponse.bind(this)),
+      totalDocs: data.total,
+      currentPage: filters.page,
+      totalPages: Math.ceil(data.total / filters.limit),
+      stats: data.stats,
+    };
   }
 }

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -1,11 +1,16 @@
 import { inject, injectable } from 'tsyringe';
 import { IAdminCategoryService } from '../../interfaces/service_interfaces/admin/ICategoryService';
 import { ICategoryRepository } from '../../interfaces/repository_interfaces/ICategoryRepository';
-import { ICreateCategoryInputDTO } from '.../../types/dtos/admin/request.dtos';
+import {
+  ICreateCategoryInputDTO,
+  IUpdateCategoryInputDTO,
+} from '.../../types/dtos/admin/request.dtos';
 import { AppError } from '../../errors/AppError';
 import { HTTP_STATUS } from '../../shared/constants/http_status_code';
 import { generateSlug } from '../../shared/utils/slug.generator.helper';
 import { toObjectId } from '../../shared/utils/database/objectId.helper';
+import { ERROR_MESSAGES } from '../../shared/constants/messages';
+import { CATEGORY_STATUS } from '../../shared/constants/constants';
 
 @injectable()
 export class CategoryService implements IAdminCategoryService {
@@ -16,7 +21,7 @@ export class CategoryService implements IAdminCategoryService {
 
   async createCategory(adminId: string, data: ICreateCategoryInputDTO): Promise<void> {
     const adminObjectId = toObjectId(adminId);
-      
+
     const existing = await this._categoryRepository.findByName(data.name);
     if (existing) {
       throw new AppError(`A category named "${data.name}" already exists`, HTTP_STATUS.CONFLICT);
@@ -26,8 +31,28 @@ export class CategoryService implements IAdminCategoryService {
 
     await this._categoryRepository.create({
       ...data,
-      slug,
+        slug,
+        isActive: true,
+      status:CATEGORY_STATUS.ACTIVE,
       createdBy: adminObjectId,
     });
+  }
+
+  async updateCategory(adminId: string, id: string, data: IUpdateCategoryInputDTO): Promise<void> {
+    const category = await this._categoryRepository.findById(id);
+    if (!category) {
+      throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
+    }
+
+    if (
+      category.status === CATEGORY_STATUS.PENDING ||
+      category.status === CATEGORY_STATUS.REJECTED
+    ) {
+      throw new AppError(ERROR_MESSAGES.CATEGORY_CANNOT_EDIT, HTTP_STATUS.BAD_REQUEST);
+    }
+
+    const updated = await this._categoryRepository.findByIdAndUpdate(id, data);
+    if (!updated)
+      throw new AppError(ERROR_MESSAGES.UNEXPECTED_SERVER_ERROR, HTTP_STATUS.INTERNAL_SERVER_ERROR);
   }
 }

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -1,5 +1,8 @@
 import { inject, injectable } from 'tsyringe';
-import { IAdminCategoryService } from '../../interfaces/service_interfaces/admin/ICategoryService';
+import {
+  IAdminCategoryService,
+  ReviewInput,
+} from '../../interfaces/service_interfaces/admin/ICategoryService';
 import { ICategoryRepository } from '../../interfaces/repository_interfaces/ICategoryRepository';
 import {
   ICreateCategoryInputDTO,
@@ -10,7 +13,11 @@ import { HTTP_STATUS } from '../../shared/constants/http_status_code';
 import { generateSlug } from '../../shared/utils/slug.generator.helper';
 import { toObjectId } from '../../shared/utils/database/objectId.helper';
 import { ERROR_MESSAGES } from '../../shared/constants/messages';
-import { CATEGORY_STATUS, CategoryStatus } from '../../shared/constants/constants';
+import {
+  APPROVE_REJECT_ACTIONS,
+  CATEGORY_STATUS,
+  CategoryStatus,
+} from '../../shared/constants/constants';
 import { PaginatedCategoryResponse, PaginatedData } from '../../types/common/IPaginationResponse';
 import { CategoryFilters } from '../../types/db';
 import {
@@ -152,5 +159,48 @@ export class CategoryService implements IAdminCategoryService {
       currentPage: page,
       totalPages: Math.ceil(total / limit),
     };
+  }
+
+  async reviewCategoryRequest(adminId: string, id: string, data: ReviewInput): Promise<void> {
+    const category = await this._categoryRepository.findById(id);
+
+    if (!category) {
+      throw new AppError(ERROR_MESSAGES.CATEGORY_REQUEST_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
+    }
+
+    if (category.status !== CATEGORY_STATUS.PENDING) {
+      throw new AppError(
+        `This request has already been ${category.status}. Cannot review again.`,
+        HTTP_STATUS.BAD_REQUEST,
+      );
+    }
+
+    if (data.action === APPROVE_REJECT_ACTIONS.APPROVE) {
+      const duplicate = await this._categoryRepository.findByName(category.name);
+      if (duplicate && duplicate._id.toString() !== id) {
+        throw new AppError(
+          `An active category named "${category.name}" already exists. ` +
+            `Reject this request and inform the vendor.`,
+          HTTP_STATUS.CONFLICT,
+        );
+      }
+
+      const slug = generateSlug(category.name);
+
+      const approved = await this._categoryRepository.reviewRequest(id, {
+        status: CATEGORY_STATUS.ACTIVE,
+        slug,
+        isActive: true,
+        adminId,
+      });
+      return;
+    }
+
+    const rejected = await this._categoryRepository.reviewRequest(id, {
+      status: CATEGORY_STATUS.REJECTED,
+      isActive: false,
+      adminId,
+      rejectionReason: data.rejectionReason!.trim(),
+    });
   }
 }

--- a/src/services/admin/category.service.ts
+++ b/src/services/admin/category.service.ts
@@ -1,14 +1,33 @@
 import { inject, injectable } from 'tsyringe';
 import { IAdminCategoryService } from '../../interfaces/service_interfaces/admin/ICategoryService';
 import { ICategoryRepository } from '../../interfaces/repository_interfaces/ICategoryRepository';
+import { ICreateCategoryInputDTO } from '.../../types/dtos/admin/request.dtos';
+import { AppError } from '../../errors/AppError';
+import { HTTP_STATUS } from '../../shared/constants/http_status_code';
+import { generateSlug } from '../../shared/utils/slug.generator.helper';
+import { toObjectId } from '../../shared/utils/database/objectId.helper';
 
 @injectable()
 export class CategoryService implements IAdminCategoryService {
-    constructor(
-        @inject('ICategoryRepository')
-        private _categoryRepository: ICategoryRepository,
-    
-    ) { }
-    
+  constructor(
+    @inject('ICategoryRepository')
+    private _categoryRepository: ICategoryRepository,
+  ) {}
 
+  async createCategory(adminId: string, data: ICreateCategoryInputDTO): Promise<void> {
+    const adminObjectId = toObjectId(adminId);
+      
+    const existing = await this._categoryRepository.findByName(data.name);
+    if (existing) {
+      throw new AppError(`A category named "${data.name}" already exists`, HTTP_STATUS.CONFLICT);
+    }
+
+    const slug = generateSlug(data.name);
+
+    await this._categoryRepository.create({
+      ...data,
+      slug,
+      createdBy: adminObjectId,
+    });
+  }
 }

--- a/src/services/vendor/package.service.ts
+++ b/src/services/vendor/package.service.ts
@@ -29,19 +29,19 @@ export class PackageService implements IPackageService {
     @inject('IVendorInfoRepository')
     private _vendorInfoRepository: IVendorInfoRepository,
     @inject('IFileStorageHandlerService')
-    private _fileStorageHandlerService: IFileStorageHandlerService
+    private _fileStorageHandlerService: IFileStorageHandlerService,
   ) {}
 
-  private async processPackageImages(images: { key: string; status: string }[]):Promise<IFile[]> {
+  private async processPackageImages(images: { key: string; status: string }[]): Promise<IFile[]> {
     const uploaded = images.filter((img) => img.status === 'UPLOADED');
     const removed = images.filter((img) => img.status === 'REMOVED');
 
     if (removed.length > 0) {
       await Promise.all(removed.map((img) => this._fileStorageHandlerService.deleteFile(img.key)));
     }
-    return uploaded.map(img => ({ key: img.key }));
+    return uploaded.map((img) => ({ key: img.key }));
   }
-//=======================================
+  //=======================================
   async fetchPackages(
     vendorId: string,
     page: number,
@@ -116,18 +116,20 @@ export class PackageService implements IPackageService {
   }
 
   //==================================================================
-    async createPackage(vendorId: string, payload: CreateBasePackageDTO): Promise<{ packageId: string }> {
-      
-      const vendorObjectId = toObjectId(vendorId);
+  async createPackage(
+    vendorId: string,
+    payload: CreateBasePackageDTO,
+  ): Promise<{ packageId: string }> {
+    const vendorObjectId = toObjectId(vendorId);
 
-      // Step 1 — Only approved vendors can create packages
-      const vendor = await this._vendorInfoRepository.findVendorWithUserId(vendorId);
-  
+    // Step 1 — Only approved vendors can create packages
+    const vendor = await this._vendorInfoRepository.findVendorWithUserId(vendorId);
+
     if (!vendor || vendor.status !== VENDOR_VERIFICATION_STATUS.APPROVED) {
       throw new AppError(ERROR_MESSAGES.VENDOR_NOT_VERIFIED, HTTP_STATUS.FORBIDDEN);
-      }
-      
-      // Step 2 — Prevent duplicate published packages with same title
+    }
+
+    // Step 2 — Prevent duplicate published packages with same title
     if (payload.title) {
       const existingPublished = await this._basePackageRepository.findOne({
         vendorId: vendorObjectId,
@@ -139,20 +141,20 @@ export class PackageService implements IPackageService {
         throw new AppError(ERROR_MESSAGES.PACKAGE_ALREADY_EXISTS, HTTP_STATUS.CONFLICT);
       }
     }
-      
-      // Step 3 — Process images if any were sent
+
+    // Step 3 — Process images if any were sent
     let imageKeys: IFile[] | undefined;
     if (payload.images && payload.images.length > 0) {
       imageKeys = await this.processPackageImages(payload.images);
     }
-       
-     const newPackage = await this._basePackageRepository.create({
-        ...payload,
-        vendorId: vendorObjectId,
-        ...(imageKeys && { images: imageKeys }),
-     });
-      
-      return {packageId: newPackage._id.toString()};
+
+    const newPackage = await this._basePackageRepository.create({
+      ...payload,
+      vendorId: vendorObjectId,
+      ...(imageKeys && { images: imageKeys }),
+    });
+
+    return { packageId: newPackage._id.toString() };
   }
   //==========================================================
   async updatePackage(vendorId: string, packageId: string, payload: CreateBasePackageDTO) {
@@ -168,21 +170,24 @@ export class PackageService implements IPackageService {
       throw new AppError(ERROR_MESSAGES.PACKAGE_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
     }
 
-    if (existingPackage.status === PACKAGE_STATUS.SOFT_DELETED || existingPackage.status === PACKAGE_STATUS.PUBLISHED) {
+    if (
+      existingPackage.status === PACKAGE_STATUS.SOFT_DELETED ||
+      existingPackage.status === PACKAGE_STATUS.PUBLISHED
+    ) {
       throw new AppError(ERROR_MESSAGES.PACKAGE_CANNOT_EDIT, HTTP_STATUS.BAD_REQUEST);
     }
-    
+
     let imageKeys: IFile[] | undefined;
-      
+
     if (payload.images) {
-         imageKeys = await this.processPackageImages(payload.images);
-      }
-      
+      imageKeys = await this.processPackageImages(payload.images);
+    }
+
     await this._basePackageRepository.findOneAndUpdate(
       { _id: packageObjectId },
       {
-          ...payload,
-          ...(imageKeys && { images: imageKeys }),
+        ...payload,
+        ...(imageKeys && { images: imageKeys }),
       },
     );
   }

--- a/src/shared/constants/cancelaation-policies.ts
+++ b/src/shared/constants/cancelaation-policies.ts
@@ -28,8 +28,6 @@ export const CANCELLATION_POLICIES = {
 
   nonRefundable: {
     label: 'Non-Refundable',
-    rules: [
-      { daysBeforeTrip: 0, refundPercent: 0 },
-    ],
+    rules: [{ daysBeforeTrip: 0, refundPercent: 0 }],
   },
 };

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -1,15 +1,14 @@
 export const PACKAGE_STATUS = {
   DRAFT: 'DRAFT',
   PUBLISHED: 'PUBLISHED',
-  SOFT_DELETED: 'SOFT_DELETED',  
+  SOFT_DELETED: 'SOFT_DELETED',
 } as const;
 
-
 export const CATEGORY_STATUS = {
-  ACTIVE:   'active',
+  ACTIVE: 'active',
   INACTIVE: 'inactive',
-  PENDING:  'pending',
+  PENDING: 'pending',
   REJECTED: 'rejected',
-} as const
+} as const;
 
-export type CategoryStatus = typeof CATEGORY_STATUS[keyof typeof CATEGORY_STATUS]
+export type CategoryStatus = (typeof CATEGORY_STATUS)[keyof typeof CATEGORY_STATUS];

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -5,3 +5,11 @@ export const PACKAGE_STATUS = {
 } as const;
 
 
+export const CATEGORY_STATUS = {
+  ACTIVE:   'active',
+  INACTIVE: 'inactive',
+  PENDING:  'pending',
+  REJECTED: 'rejected',
+} as const
+
+export type CategoryStatus = typeof CATEGORY_STATUS[keyof typeof CATEGORY_STATUS]

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -12,3 +12,11 @@ export const CATEGORY_STATUS = {
 } as const;
 
 export type CategoryStatus = (typeof CATEGORY_STATUS)[keyof typeof CATEGORY_STATUS];
+
+export const APPROVE_REJECT_ACTIONS = {
+  APPROVE: 'approve',
+  REJECT: 'rejected',
+} as const;
+
+export type ApproveRejectActions =
+  (typeof APPROVE_REJECT_ACTIONS)[keyof typeof APPROVE_REJECT_ACTIONS];

--- a/src/shared/constants/messages.ts
+++ b/src/shared/constants/messages.ts
@@ -28,6 +28,8 @@ export const SUCCESS_MESSAGES = {
   CATEGORY_UPDATED: 'Category updated successfully',
   CATEGORY_ACTIVATED: 'Category activated successfully',
   CATEGORY_DEACTIVATED: 'Category deactivated successfully',
+  CATEGORY_REQUEST_APPROVED: 'Category request approved and is now live',
+  CATEGORY_REQUEST_REJECTED: 'Category request rejected',
 } as const;
 
 export const ERROR_MESSAGES = {
@@ -86,5 +88,6 @@ export const ERROR_MESSAGES = {
   // category
   CATEGORY_NOT_FOUND: 'Category not found',
   CATEGORY_CANNOT_EDIT: 'This Category cannot be edited',
+  CATEGORY_REQUEST_NOT_FOUND: 'Category request not found',
   CANNOT_TOGGLE: 'Cannot toggle status of a vendor category request.',
 } as const;

--- a/src/shared/constants/messages.ts
+++ b/src/shared/constants/messages.ts
@@ -21,7 +21,10 @@ export const SUCCESS_MESSAGES = {
   EMAIL_UPDATED: 'Email updated Successfully',
   PROFILE_UPDATED: 'Profile updated successfully',
   PACKAGE_CREATION_SUCCESS: 'Package creation successfull',
-  PACKAGE_UPDATION_SUCCESS: 'Package updation success'
+  PACKAGE_UPDATION_SUCCESS: 'Package updation success',
+
+  // category
+  CATEGORY_CREATED: 'Category created successfully',
 } as const;
 
 export const ERROR_MESSAGES = {

--- a/src/shared/constants/messages.ts
+++ b/src/shared/constants/messages.ts
@@ -25,6 +25,7 @@ export const SUCCESS_MESSAGES = {
 
   // category
   CATEGORY_CREATED: 'Category created successfully',
+  CATEGORY_UPDATED: 'Category updated successfully',
 } as const;
 
 export const ERROR_MESSAGES = {
@@ -79,4 +80,8 @@ export const ERROR_MESSAGES = {
   PACKAGE_NOT_FOUND: 'Package not found',
   PACKAGE_ACTIVE: 'This package is not active and cannot be edited.',
   PACKAGE_CANNOT_EDIT: 'This package cannot be edited.',
+
+  // category
+  CATEGORY_NOT_FOUND: 'Category not found',
+  CATEGORY_CANNOT_EDIT: 'This Category cannot be edited',
 } as const;

--- a/src/shared/constants/messages.ts
+++ b/src/shared/constants/messages.ts
@@ -26,6 +26,8 @@ export const SUCCESS_MESSAGES = {
   // category
   CATEGORY_CREATED: 'Category created successfully',
   CATEGORY_UPDATED: 'Category updated successfully',
+  CATEGORY_ACTIVATED: 'Category activated successfully',
+  CATEGORY_DEACTIVATED: 'Category deactivated successfully',
 } as const;
 
 export const ERROR_MESSAGES = {
@@ -84,4 +86,5 @@ export const ERROR_MESSAGES = {
   // category
   CATEGORY_NOT_FOUND: 'Category not found',
   CATEGORY_CANNOT_EDIT: 'This Category cannot be edited',
+  CANNOT_TOGGLE: 'Cannot toggle status of a vendor category request.',
 } as const;

--- a/src/shared/utils/pagination.helper.ts
+++ b/src/shared/utils/pagination.helper.ts
@@ -9,7 +9,7 @@ export interface PaginationOptions {
 
 export const getPaginationOptions = (req: Request): PaginationOptions => {
   const page = parseInt(req.query.page as string) || 1;
-  const limit = parseInt(req.query.limit as string) || 5;
+  const limit = parseInt(req.query.limit as string) || 10;
   const search = (req.query.search as string) || '';
   const selectedFilter = (req.query.selectedFilter as string) || '';
 

--- a/src/shared/utils/slug.generator.helper.ts
+++ b/src/shared/utils/slug.generator.helper.ts
@@ -1,0 +1,9 @@
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')   
+    .replace(/\s+/g, '-')           
+    .replace(/-+/g, '-')          
+    .replace(/^-+|-+$/g, '')       
+}

--- a/src/shared/utils/slug.generator.helper.ts
+++ b/src/shared/utils/slug.generator.helper.ts
@@ -2,8 +2,8 @@ export function generateSlug(name: string): string {
   return name
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9\s-]/g, '')   
-    .replace(/\s+/g, '-')           
-    .replace(/-+/g, '-')          
-    .replace(/^-+|-+$/g, '')       
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }

--- a/src/types/common/IPaginationResponse.ts
+++ b/src/types/common/IPaginationResponse.ts
@@ -1,6 +1,13 @@
+import { CategoryResponseDTO } from '../../types/dtos/admin/response.dtos';
+import { CategoryStats } from '../../types/type';
+
 export interface PaginatedData<T> {
   data: T[];
   currentPage?: number;
   totalPages?: number;
   totalDocs?: number;
+}
+
+export interface PaginatedCategoryResponse extends PaginatedData<CategoryResponseDTO> {
+  stats: CategoryStats;
 }

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,0 +1,16 @@
+import { CategoryStatus } from '../shared/constants/constants';
+import { ICategory } from './entities/category.entity';
+import { CategoryStats } from './type';
+
+export interface CategoryFilters {
+  status?: CategoryStatus;
+  search?: string;
+  page: number;
+  limit: number;
+}
+
+export interface CategoryFindAllResult {
+  categories: ICategory[];
+  stats: CategoryStats;
+  total: number; // total matching current filters (for pagination)
+}

--- a/src/types/dtos/admin/request.dtos.ts
+++ b/src/types/dtos/admin/request.dtos.ts
@@ -12,3 +12,5 @@ export interface ICreateCategoryInputDTO {
   description: string;
   icon?: IFile;
 }
+
+export type IUpdateCategoryInputDTO = Partial<Omit<ICreateCategoryInputDTO, 'name'>>;

--- a/src/types/dtos/admin/request.dtos.ts
+++ b/src/types/dtos/admin/request.dtos.ts
@@ -1,14 +1,14 @@
 import { IFiles } from 'types/entities/vendor.info.entity';
 import { VENDOR_STATUS } from '../../../shared/constants/common';
+import { IFile } from 'types/entities/base-package.entity';
 
 export interface VendorVerificationUpdateDTO {
   status: VENDOR_STATUS.Approved | VENDOR_STATUS.Rejected;
   reasonForReject?: string; // optional for approval, required for rejection
 }
 
-export interface ICategoryRequestDTO {
+export interface ICreateCategoryInputDTO {
   name: string;
   description: string;
-  icon?: IFiles; 
-  isActive?: boolean;
+  icon?: IFile;
 }

--- a/src/types/dtos/admin/request.dtos.ts
+++ b/src/types/dtos/admin/request.dtos.ts
@@ -14,3 +14,11 @@ export interface ICreateCategoryInputDTO {
 }
 
 export type IUpdateCategoryInputDTO = Partial<Omit<ICreateCategoryInputDTO, 'name'>>;
+
+export interface ReviewRequestDTO {
+  status: 'active' | 'rejected';
+  isActive: boolean;
+  adminId: string;
+  slug?: string;
+  rejectionReason?: string;
+}

--- a/src/types/dtos/admin/request.dtos.ts
+++ b/src/types/dtos/admin/request.dtos.ts
@@ -1,6 +1,14 @@
+import { IFiles } from 'types/entities/vendor.info.entity';
 import { VENDOR_STATUS } from '../../../shared/constants/common';
 
 export interface VendorVerificationUpdateDTO {
   status: VENDOR_STATUS.Approved | VENDOR_STATUS.Rejected;
   reasonForReject?: string; // optional for approval, required for rejection
+}
+
+export interface ICategoryRequestDTO {
+  name: string;
+  description: string;
+  icon?: IFiles; 
+  isActive?: boolean;
 }

--- a/src/types/dtos/admin/response.dtos.ts
+++ b/src/types/dtos/admin/response.dtos.ts
@@ -39,6 +39,7 @@ export interface CategoryResponseDTO {
 }
 
 export interface CategoryRequestResponseDTO {
+  id: string;
   name: string;
   requested: {
     name: string;
@@ -46,5 +47,17 @@ export interface CategoryRequestResponseDTO {
   } | null;
   vendorNote: string | null;
   date: string;
+  status: CategoryStatus;
+}
+
+export interface CategoryRequestReviewedResponseDTO {
+  id: string;
+  name: string;
+  requested: {
+    name: string;
+    email: string;
+  } | null;
+  adminNote: string | null;
+  updatedDate: string;
   status: CategoryStatus;
 }

--- a/src/types/dtos/admin/response.dtos.ts
+++ b/src/types/dtos/admin/response.dtos.ts
@@ -37,3 +37,14 @@ export interface CategoryResponseDTO {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export interface CategoryRequestResponseDTO {
+  name: string;
+  requested: {
+    name: string;
+    email: string;
+  } | null;
+  vendorNote: string | null;
+  date: string;
+  status: CategoryStatus;
+}

--- a/src/types/dtos/admin/response.dtos.ts
+++ b/src/types/dtos/admin/response.dtos.ts
@@ -1,5 +1,6 @@
 import { IFile } from 'types/entities/base-package.entity';
 import { PackageStatus } from '../../../types/type';
+import { CategoryStatus } from '../../../shared/constants/constants';
 export interface UserResponseDTO {
   id: string;
   name: string;
@@ -20,4 +21,19 @@ export interface BasePackageSingleResponseDTO {
   category: string;
   difficultyLevel: string;
   basePrice: number;
+}
+
+export interface CategoryResponseDTO {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  icon: IFile | null;
+  isActive: boolean;
+  status: CategoryStatus;
+  createdBy: string | null;
+  requestedBy: string | null;
+  rejectionReason: string | null;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/src/types/entities/base-package.entity.ts
+++ b/src/types/entities/base-package.entity.ts
@@ -48,7 +48,7 @@ export interface IBasePackageEntity extends Document {
   inclusions?: string[];
   exclusions?: string[];
   packingList?: string[];
-  cancellationPolicy?: 'Flexible' | 'Moderate' | 'Strict' | 'Non-Refundable' ;
+  cancellationPolicy?: 'Flexible' | 'Moderate' | 'Strict' | 'Non-Refundable';
 
   difficultyLevel?: DifficultyLevel;
 

--- a/src/types/entities/category.entity.ts
+++ b/src/types/entities/category.entity.ts
@@ -1,18 +1,18 @@
-import mongoose, { Document, Types } from "mongoose";
-import { CategoryStatus } from "shared/constants/constants";
-import { IFile } from "./base-package.entity";
+import mongoose, { Document, Types } from 'mongoose';
+import { CategoryStatus } from 'shared/constants/constants';
+import { IFile } from './base-package.entity';
 
 export interface ICategory extends Document {
-  _id:             mongoose.Types.ObjectId
-  name:            string
-  slug:            string   // "Adventure Trekking" → "adventure-trekking"
-  description?:    string
-  icon?:           IFile    
-  isActive:        boolean      
-  status:          CategoryStatus
-  createdBy?:      Types.ObjectId  
-  requestedBy?:    Types.ObjectId  
-  rejectionReason?: string      
-  createdAt:       Date
-  updatedAt:       Date
+  _id: mongoose.Types.ObjectId;
+  name: string;
+  slug: string; // "Adventure Trekking" → "adventure-trekking"
+  description?: string;
+  icon?: IFile;
+  isActive: boolean;
+  status: CategoryStatus;
+  createdBy?: Types.ObjectId;
+  requestedBy?: Types.ObjectId;
+  rejectionReason?: string;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/src/types/entities/category.entity.ts
+++ b/src/types/entities/category.entity.ts
@@ -1,12 +1,18 @@
-import { Document, Types } from "mongoose";
-import { IFiles } from "./vendor.info.entity";
+import mongoose, { Document, Types } from "mongoose";
+import { CategoryStatus } from "shared/constants/constants";
+import { IFile } from "./base-package.entity";
 
 export interface ICategory extends Document {
-  name: string;
-  icon?: IFiles; 
-  description?: string;
-  isActive: boolean;
-  createdBy: Types.ObjectId; // Admin ObjectId reference
-  createdAt: Date;
-  updatedAt: Date;
+  _id:             mongoose.Types.ObjectId
+  name:            string
+  slug:            string   // "Adventure Trekking" → "adventure-trekking"
+  description?:    string
+  icon?:           IFile    
+  isActive:        boolean      
+  status:          CategoryStatus
+  createdBy?:      Types.ObjectId  
+  requestedBy?:    Types.ObjectId  
+  rejectionReason?: string      
+  createdAt:       Date
+  updatedAt:       Date
 }

--- a/src/types/entities/category.entity.ts
+++ b/src/types/entities/category.entity.ts
@@ -1,0 +1,12 @@
+import { Document, Types } from "mongoose";
+import { IFiles } from "./vendor.info.entity";
+
+export interface ICategory extends Document {
+  name: string;
+  icon?: IFiles; 
+  description?: string;
+  isActive: boolean;
+  createdBy: Types.ObjectId; // Admin ObjectId reference
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/types/entities/category.entity.ts
+++ b/src/types/entities/category.entity.ts
@@ -13,6 +13,12 @@ export interface ICategory extends Document {
   createdBy?: Types.ObjectId;
   requestedBy?: Types.ObjectId;
   rejectionReason?: string;
+  vendorNote?: string;
+  adminNote?: string;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface ICategoryRequestPopulated extends Omit<ICategory, 'requestedBy'> {
+  requestedBy: { _id: string; name: string; email: string };
 }

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,3 +1,10 @@
 import { PACKAGE_STATUS } from '../shared/constants/constants';
 
 export type PackageStatus = (typeof PACKAGE_STATUS)[keyof typeof PACKAGE_STATUS];
+
+export interface CategoryStats {
+  total: number;
+  active: number;
+  inactive: number;
+  pendingApproval: number;
+}

--- a/src/validators/admin/category.validation.ts
+++ b/src/validators/admin/category.validation.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+const categoryName = z
+  .string({ required_error: 'Category name is required' })
+  .trim()
+  .min(2, 'Category name must be at least 2 characters')
+  .max(60, 'Category name cannot exceed 60 characters');
+
+const categoryDescription = z
+  .string()
+  .trim()
+  .max(300, 'Description cannot exceed 300 characters')
+  .optional();
+
+const categoryIcon = z
+  .object({
+    key: z.string().trim(),
+  })
+  .optional();
+
+// create
+
+const createCategoryBodySchema = z.object({
+  name: categoryName,
+  description: categoryDescription,
+  icon: categoryIcon,
+});
+
+export const createCategorySchema = z.object({
+  body: createCategoryBodySchema,
+});
+
+

--- a/src/validators/admin/category.validation.ts
+++ b/src/validators/admin/category.validation.ts
@@ -75,3 +75,20 @@ export const reviewCategorySchema = z.object({
 });
 
 //=============================
+export const reviewedCategoryBodySchema = z
+  .object({
+    selectedFilter: z
+      .enum(['active', 'rejected'], {
+        message: 'Filter must be "active" or "rejected"',
+      })
+      .optional(),
+    page: z.string().optional(),
+    limit: z.string().optional(),
+    search: z.string().optional(),
+  })
+  .strict();
+
+export const reviewedCategorySchema = z.object({
+  query: reviewedCategoryBodySchema,
+});
+//=================================================

--- a/src/validators/admin/category.validation.ts
+++ b/src/validators/admin/category.validation.ts
@@ -49,3 +49,29 @@ export const updateCategorySchema = z.object({
   params: z.object({ id: z.string() }),
   body: updateCategoryBodySchema,
 });
+
+//=============================
+export const reviewCategoryBodySchema = z
+  .object({
+    action: z.enum(['approve', 'rejected'], {
+      required_error: 'action is required',
+      invalid_type_error: 'action must be "approve" or "reject"',
+    }),
+    rejectionReason: z
+      .string()
+      .trim()
+      .min(10, 'Rejection reason must be at least 10 characters')
+      .max(500, 'Rejection reason cannot exceed 500 characters')
+      .optional(),
+  })
+  .refine((data) => !(data.action === 'rejected' && !data.rejectionReason?.trim()), {
+    message: 'rejectionReason is required when action is "reject"',
+    path: ['rejectionReason'],
+  });
+
+export const reviewCategorySchema = z.object({
+  params: z.object({ id: z.string() }),
+  body: reviewCategoryBodySchema,
+});
+
+//=============================

--- a/src/validators/admin/category.validation.ts
+++ b/src/validators/admin/category.validation.ts
@@ -13,7 +13,10 @@ const categoryDescription = z
 
 const categoryIcon = z
   .object({
-    key: z.string().trim(),
+    key: z.string({ required_error: "Icon key required" }).trim(),
+  },{
+    invalid_type_error: "Input type error",
+    required_error: "Icon is required",
   })
   .optional();
 
@@ -29,4 +32,17 @@ export const createCategorySchema = z.object({
   body: createCategoryBodySchema,
 });
 
+// update
+export const updateCategoryBodySchema = z.object({
+  description:categoryDescription,
+  icon:categoryIcon,
+}).refine(
+  data => Object.values(data).some(v => v !== undefined),
+  { message: 'At least one field must be provided for update' }
+)
 
+
+export const updateCategorySchema = z.object({
+    params: z.object({id: z.string(),}),
+    body: updateCategoryBodySchema,
+});

--- a/src/validators/admin/category.validation.ts
+++ b/src/validators/admin/category.validation.ts
@@ -12,12 +12,15 @@ const categoryDescription = z
   .optional();
 
 const categoryIcon = z
-  .object({
-    key: z.string({ required_error: "Icon key required" }).trim(),
-  },{
-    invalid_type_error: "Input type error",
-    required_error: "Icon is required",
-  })
+  .object(
+    {
+      key: z.string({ required_error: 'Icon key required' }).trim(),
+    },
+    {
+      invalid_type_error: 'Input type error',
+      required_error: 'Icon is required',
+    },
+  )
   .optional();
 
 // create
@@ -33,16 +36,16 @@ export const createCategorySchema = z.object({
 });
 
 // update
-export const updateCategoryBodySchema = z.object({
-  description:categoryDescription,
-  icon:categoryIcon,
-}).refine(
-  data => Object.values(data).some(v => v !== undefined),
-  { message: 'At least one field must be provided for update' }
-)
-
+export const updateCategoryBodySchema = z
+  .object({
+    description: categoryDescription,
+    icon: categoryIcon,
+  })
+  .refine((data) => Object.values(data).some((v) => v !== undefined), {
+    message: 'At least one field must be provided for update',
+  });
 
 export const updateCategorySchema = z.object({
-    params: z.object({id: z.string(),}),
-    body: updateCategoryBodySchema,
+  params: z.object({ id: z.string() }),
+  body: updateCategoryBodySchema,
 });

--- a/src/validators/vendor/package/base-package.schema.ts
+++ b/src/validators/vendor/package/base-package.schema.ts
@@ -31,7 +31,7 @@ const basePackageBackendSchema = z.object({
 
 export const packageImageSchema = z.object({
   key: z.string(), // Present for existing images (S3 Key)
-  file: z.instanceof(File).optional(), 
+  file: z.instanceof(File).optional(),
   status: z.enum(['PENDING_UPLOAD', 'UPLOADED', 'REMOVED']),
 });
 
@@ -72,7 +72,7 @@ const draftPackageBackendSchema = basePackageBackendSchema.extend({
   exclusions: z.array(z.string()).optional(),
   packingList: z.array(z.string()).optional(),
 
- cancellationPolicy: z.enum(["Flexible", "Moderate", "Strict", "Non-Refundable",]).optional(),
+  cancellationPolicy: z.enum(['Flexible', 'Moderate', 'Strict', 'Non-Refundable']).optional(),
 
   isActive: z.boolean().optional(),
 
@@ -127,17 +127,17 @@ export const publishPackageBackendSchema = basePackageBackendSchema
     location: z
       .string()
       .min(2, 'Location must be at least 2 characters')
-      .max(100, 'Location must be at most 100 characters'), 
-    
+      .max(100, 'Location must be at most 100 characters'),
+
     pickupLocation: z
       .string()
       .min(2, 'Pickup location must be at least 2 characters')
       .max(100, 'Pickup location must be at most 100 characters'),
-    
-      usp: z
-        .string()
-        .min(2, 'USP must be at least 2 characters')
-        .max(100, 'USP must be at most 100 characters'),
+
+    usp: z
+      .string()
+      .min(2, 'USP must be at least 2 characters')
+      .max(100, 'USP must be at most 100 characters'),
 
     category: z.enum(CATEGORY_ENUM, {
       errorMap: () => ({ message: 'Please select a valid category' }),
@@ -174,7 +174,7 @@ export const publishPackageBackendSchema = basePackageBackendSchema
     exclusions: z.array(z.string().min(1)),
     packingList: z.array(z.string()),
 
-    cancellationPolicy: z.enum(["Flexible", "Moderate", "Strict", "Non-Refundable"], {
+    cancellationPolicy: z.enum(['Flexible', 'Moderate', 'Strict', 'Non-Refundable'], {
       errorMap: () => ({ message: 'Please select a valid cancellation policy' }),
     }),
 


### PR DESCRIPTION
## What does this PR do?
Implements the backend API for admin category management workflow.


## Endpoints Added
- GET    /admin/category                      - List categories (search, pagination, filter)
- POST   /admin/category                      - Create category
- PATCH  /admin/category/:id/toggle           - Activate / Inactivate category
- GET    /admin/category/requests/pending     - Vendor pending requests
- GET    /admin/category/requests/reviewed    - Reviewed requests (approved/rejected)
- PATCH  /admin/category/requests/:id/review  - Approve or reject vendor request

## Changes
- Category repository with search, pagination, status filter
- Vendor request review with rejection reason
- Resolved requests query with optional status filter
- Input validation with Zod DTOs on all endpoints