### PR TITLE
refactor (vendor) base package 

### DIFF
--- a/src/controllers/vendor/vendor-package.controller.ts
+++ b/src/controllers/vendor/vendor-package.controller.ts
@@ -10,6 +10,7 @@ import { RequestHandler } from 'express';
 import { ParamsDictionary } from 'express-serve-static-core';
 import { getPaginationOptions } from '../../shared/utils/pagination.helper';
 import { CreateBasePackageDTO } from 'validators/vendor/package/base-package.schema';
+import { FilterType } from 'types/db';
 
 @injectable()
 export class VendorPackageController implements IVendorPackageController {
@@ -20,7 +21,7 @@ export class VendorPackageController implements IVendorPackageController {
 
   createPackage = asyncHandler(async (req, res) => {
     const vendorId = req.user?.id!;
-    const payload:CreateBasePackageDTO = req.body;
+    const payload: CreateBasePackageDTO = req.body;
 
     const { packageId } = await this._packageService.createPackage(vendorId, payload);
 
@@ -49,15 +50,13 @@ export class VendorPackageController implements IVendorPackageController {
   fetchPackages = asyncHandler(async (req, res) => {
     const vendorId = req.user?.id!;
     const { page, limit, search, selectedFilter } = getPaginationOptions(req);
-
-    const packages = await this._packageService.fetchPackages(
-      vendorId,
+    const filters: FilterType = {
       page,
       limit,
       search,
       selectedFilter,
-    );
-
+    };
+    const packages = await this._packageService.fetchPackages(vendorId, filters);
     const successResponse: IApiResponse<typeof packages> = {
       success: SUCCESS_STATUS.SUCCESS,
       message: SUCCESS_MESSAGES.OK,

--- a/src/controllers/vendor/vendor-package.controller.ts
+++ b/src/controllers/vendor/vendor-package.controller.ts
@@ -9,6 +9,7 @@ import { IApiResponse } from 'types/common/IApiResponse';
 import { RequestHandler } from 'express';
 import { ParamsDictionary } from 'express-serve-static-core';
 import { getPaginationOptions } from '../../shared/utils/pagination.helper';
+import { CreateBasePackageDTO } from 'validators/vendor/package/base-package.schema';
 
 @injectable()
 export class VendorPackageController implements IVendorPackageController {
@@ -19,7 +20,7 @@ export class VendorPackageController implements IVendorPackageController {
 
   createPackage = asyncHandler(async (req, res) => {
     const vendorId = req.user?.id!;
-    const payload = req.body;
+    const payload:CreateBasePackageDTO = req.body;
 
     const { packageId } = await this._packageService.createPackage(vendorId, payload);
 

--- a/src/interfaces/repository_interfaces/IBasePackageRepository.ts
+++ b/src/interfaces/repository_interfaces/IBasePackageRepository.ts
@@ -1,4 +1,13 @@
-import { IBasePackage } from '../../types/entities/base-package.entity';
+import { FilterType } from 'types/db';
+import {
+  IBasePackageEntity,
+  IBasePackagePopulated,
+} from '../../types/entities/base-package.entity';
 import { IBaseRepository } from './IBaseRepository';
 
-export interface IBasePackageRepository extends IBaseRepository<IBasePackage> {}
+export interface IBasePackageRepository extends IBaseRepository<IBasePackageEntity> {
+  findPackages(
+    vendorId: string,
+    filters: FilterType,
+  ): Promise<{ requests: IBasePackagePopulated[]; total: number }>;
+}

--- a/src/interfaces/repository_interfaces/IBaseRepository.ts
+++ b/src/interfaces/repository_interfaces/IBaseRepository.ts
@@ -10,6 +10,11 @@ export interface IBaseRepository<T> {
 
   findOne(query: Partial<T>): Promise<T | null>;
 
+  findOnePopulated<P = T>(
+    query: FilterQuery<T>,
+    populate: { path: string; select?: string },
+  ): Promise<P | null>; 
+
   countDocuments(filter?: FilterQuery<T>): Promise<number>;
 
   findByIdAndUpdate(

--- a/src/interfaces/service_interfaces/vendor/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/vendor/ICategoryService.ts
@@ -1,7 +1,10 @@
 import { PaginatedData } from 'types/common/IPaginationResponse';
 import { FilterType } from 'types/db';
 import { VendorCategoryRequestInputDTO } from 'types/dtos/vendor/request.dtos';
-import { ActiveCategoriesResponseDTO, VendorRequestedCategoryResponseDTO } from 'types/dtos/vendor/response.dtos';
+import {
+  ActiveCategoriesResponseDTO,
+  VendorRequestedCategoryResponseDTO,
+} from 'types/dtos/vendor/response.dtos';
 
 export interface IVendorCategoryService {
   getRequestedcategories(

--- a/src/interfaces/service_interfaces/vendor/ICategoryService.ts
+++ b/src/interfaces/service_interfaces/vendor/ICategoryService.ts
@@ -1,14 +1,14 @@
 import { PaginatedData } from 'types/common/IPaginationResponse';
 import { FilterType } from 'types/db';
 import { VendorCategoryRequestInputDTO } from 'types/dtos/vendor/request.dtos';
-import { VendorRequestedCategoryResponseDTO } from 'types/dtos/vendor/response.dtos';
+import { ActiveCategoriesResponseDTO, VendorRequestedCategoryResponseDTO } from 'types/dtos/vendor/response.dtos';
 
 export interface IVendorCategoryService {
   getRequestedcategories(
     vendorId: string,
     filters: FilterType,
   ): Promise<PaginatedData<VendorRequestedCategoryResponseDTO>>;
-  getActiveCategories(): Promise<string[]>;
+  getActiveCategories(): Promise<ActiveCategoriesResponseDTO[]>;
 
   requestCategory(vendorId: string, data: VendorCategoryRequestInputDTO): Promise<void>;
 }

--- a/src/interfaces/service_interfaces/vendor/IPackageService.ts
+++ b/src/interfaces/service_interfaces/vendor/IPackageService.ts
@@ -3,17 +3,15 @@ import {
   BasePackageResponseDTO,
   CreateBasePackageDTO,
 } from 'validators/vendor/package/base-package.schema';
-import { BasePackageSingleResponseDTO } from '../../../types/dtos/admin/response.dtos';
+import { BasePackageSingleResponseDTO, PackageDetailDTO } from '../../../types/dtos/admin/response.dtos';
+import { FilterType } from 'types/db';
 
 export interface IPackageService {
   fetchPackages(
     vendorId: string,
-    page: number,
-    limit: number,
-    search?: string,
-    selectedFilter?: string,
+    filters: FilterType,
   ): Promise<PaginatedData<BasePackageSingleResponseDTO>>;
   createPackage(vendorId: string, payload: CreateBasePackageDTO): Promise<{ packageId: string }>;
   updatePackage(vendorId: string, packageId: string, payload: CreateBasePackageDTO): Promise<void>;
-  fetchPackagesWithId(vendorId: string, packageId: string): Promise<BasePackageResponseDTO>;
+  fetchPackagesWithId(vendorId: string, packageId: string): Promise<PackageDetailDTO>;
 }

--- a/src/middlewares/validate.dto.middleware.ts
+++ b/src/middlewares/validate.dto.middleware.ts
@@ -20,6 +20,7 @@ export const validateDTO =
       next();
     } catch (error) {
       if (error instanceof ZodError) {
+          // console.log("ZOD ERRORS:", JSON.stringify(error.errors, null, 2));
         next(new AppError(error.errors[0].message, HTTP_STATUS.BAD_REQUEST));
         return;
       }

--- a/src/models/package.model.ts
+++ b/src/models/package.model.ts
@@ -19,7 +19,7 @@ const activitySchema = new Schema(
     title: { type: String },
     description: { type: String },
     location: { type: String },
-    specials: { type: [String], default: []},
+    specials: { type: [String], default: [] },
     included: { type: Boolean },
   },
   { _id: false },
@@ -48,16 +48,18 @@ const packageSchema = new Schema<IBasePackageEntity>(
 
     location: { type: String, trim: true },
 
+    state: { type: String, trim: true },
+
     usp: { type: String, trim: true },
 
     categoryId: {
       type: Schema.Types.ObjectId,
-      ref: 'Category'
+      ref: 'Category',
     },
 
     difficultyLevel: {
       type: String,
-      enum: ['easy', 'moderate', 'challenging', 'extreme'],
+      enum: ['Easy', 'Moderate', 'Challenging', 'Extreme'],
     },
 
     description: { type: String },

--- a/src/models/package.model.ts
+++ b/src/models/package.model.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, model } from 'mongoose';
 import { IBasePackageEntity } from '../types/entities/base-package.entity';
 import { PACKAGE_STATUS } from '../shared/constants/constants';
+import { DifficultyLevel } from '../types/entities/base-package.entity';
 
 /* ---------- Sub Schemas ---------- */
 
@@ -18,10 +19,7 @@ const activitySchema = new Schema(
     title: { type: String },
     description: { type: String },
     location: { type: String },
-    type: {
-      type: String,
-      enum: ['tour', 'transport', 'accommodation', 'activity', 'meal'],
-    },
+    specials: { type: [String], default: []},
     included: { type: Boolean },
   },
   { _id: false },
@@ -50,13 +48,12 @@ const packageSchema = new Schema<IBasePackageEntity>(
 
     location: { type: String, trim: true },
 
-    pickupLocation: { type: String, trim: true },
 
     usp: { type: String, trim: true },
 
-    category: {
-      type: String,
-      enum: ['adventure', 'cultural', 'relaxation', 'luxury'],
+    categoryId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Category'
     },
 
     difficultyLevel: {

--- a/src/models/package.model.ts
+++ b/src/models/package.model.ts
@@ -48,7 +48,6 @@ const packageSchema = new Schema<IBasePackageEntity>(
 
     location: { type: String, trim: true },
 
-
     usp: { type: String, trim: true },
 
     categoryId: {

--- a/src/repositories/base-package-repository.ts
+++ b/src/repositories/base-package-repository.ts
@@ -1,8 +1,10 @@
 import { injectable } from 'tsyringe';
 import { IBasePackageRepository } from '../interfaces/repository_interfaces/IBasePackageRepository';
 import { BaseRepository } from './base.repository';
-import { IBasePackageEntity } from '../types/entities/base-package.entity';
+import { IBasePackageEntity, IBasePackagePopulated } from '../types/entities/base-package.entity';
 import { PackageModel } from '../models/package.model';
+import { FilterType } from 'types/db';
+import mongoose from 'mongoose';
 
 @injectable()
 export class BasePackageRepository
@@ -11,5 +13,37 @@ export class BasePackageRepository
 {
   constructor() {
     super(PackageModel);
+  }
+
+  async findPackages(
+    vendorId: string,
+    filters: FilterType,
+  ): Promise<{ requests: IBasePackagePopulated[]; total: number }> {
+    const query: mongoose.FilterQuery<IBasePackageEntity> = {
+      vendorId,
+    };
+
+    if (filters.search?.trim()) {
+      const regex = new RegExp(filters.search.trim(), 'i');
+      query.$or = [{ location: { $regex: regex } }, { state: { $regex: regex } }];
+    }
+    if (filters.selectedFilter?.trim()) {
+      query.status = filters.selectedFilter;
+    }
+    const skip = (filters.page - 1) * filters.limit;
+
+    const [requests, total] = await Promise.all([
+      this.model
+        .find(query)
+        .populate<{ categoryId: { name: string } }>('categoryId', 'name')
+        .sort({ createdAt: 1 })
+        .skip(skip)
+        .limit(filters.limit)
+        .lean<IBasePackagePopulated[]>(),
+
+      this.countDocuments(query),
+    ]);
+
+    return { requests, total };
   }
 }

--- a/src/repositories/base.repository.ts
+++ b/src/repositories/base.repository.ts
@@ -21,6 +21,16 @@ export class BaseRepository<T> implements IBaseRepository<T> {
     return await this.model.findOne(query).exec();
   }
 
+async findOnePopulated<P = T>(
+  query: FilterQuery<T>,
+  populate: { path: string; select?: string },
+ ): Promise<P | null> {
+  return await this.model
+    .findOne(query)
+    .populate(populate.path, populate.select)
+    .lean() as P | null;
+}
+
   async findById(id: string): Promise<T | null> {
     return await this.model.findById(id).exec();
   }

--- a/src/services/vendor/category.service.ts
+++ b/src/services/vendor/category.service.ts
@@ -8,7 +8,7 @@ import { HTTP_STATUS } from '../../shared/constants/http_status_code';
 import { PaginatedData } from '../../types/common/IPaginationResponse';
 import { FilterType } from '../../types/db';
 import { VendorCategoryRequestInputDTO } from '../../types/dtos/vendor/request.dtos';
-import { VendorRequestedCategoryResponseDTO } from '../../types/dtos/vendor/response.dtos';
+import { ActiveCategoriesResponseDTO, VendorRequestedCategoryResponseDTO } from '../../types/dtos/vendor/response.dtos';
 import { generateSlug } from '../../shared/utils/slug.generator.helper';
 import { CategoryMapper } from '../../shared/mappers/category.mapper';
 @injectable()
@@ -87,8 +87,8 @@ export class VendorCategoryService implements IVendorCategoryService {
     });
   }
 
-  async getActiveCategories(): Promise<string[]> {
+  async getActiveCategories(): Promise<ActiveCategoriesResponseDTO[]> {
     const categories = await this._categoryRepository.findActiveCategories();
-    return categories.map((cat) => cat.name);
+    return categories.map(CategoryMapper.toActiveCategoriesResponse);
   }
 }

--- a/src/services/vendor/category.service.ts
+++ b/src/services/vendor/category.service.ts
@@ -8,7 +8,10 @@ import { HTTP_STATUS } from '../../shared/constants/http_status_code';
 import { PaginatedData } from '../../types/common/IPaginationResponse';
 import { FilterType } from '../../types/db';
 import { VendorCategoryRequestInputDTO } from '../../types/dtos/vendor/request.dtos';
-import { ActiveCategoriesResponseDTO, VendorRequestedCategoryResponseDTO } from '../../types/dtos/vendor/response.dtos';
+import {
+  ActiveCategoriesResponseDTO,
+  VendorRequestedCategoryResponseDTO,
+} from '../../types/dtos/vendor/response.dtos';
 import { generateSlug } from '../../shared/utils/slug.generator.helper';
 import { CategoryMapper } from '../../shared/mappers/category.mapper';
 @injectable()

--- a/src/services/vendor/package.service.ts
+++ b/src/services/vendor/package.service.ts
@@ -2,7 +2,6 @@ import { inject, injectable } from 'tsyringe';
 import { IPackageService } from '../../interfaces/service_interfaces/vendor/IPackageService';
 import { IVendorInfoRepository } from '../../interfaces/repository_interfaces/IVendorInfoRepository';
 import { IBasePackageRepository } from '../../interfaces/repository_interfaces/IBasePackageRepository';
-
 import {
   CreateBasePackageDTO,
   BasePackageResponseDTO,
@@ -20,7 +19,7 @@ import { FilterQuery } from 'mongoose';
 import { IBasePackageEntity, IFile } from '../../types/entities/base-package.entity';
 import { PACKAGE_STATUS } from '../../shared/constants/constants';
 import { IFileStorageHandlerService } from '../../interfaces/service_interfaces/IFileStorageBusinessService';
-
+import { ICategoryRepository } from '../../interfaces/repository_interfaces/ICategoryRepository';
 @injectable()
 export class PackageService implements IPackageService {
   constructor(
@@ -30,6 +29,9 @@ export class PackageService implements IPackageService {
     private _vendorInfoRepository: IVendorInfoRepository,
     @inject('IFileStorageHandlerService')
     private _fileStorageHandlerService: IFileStorageHandlerService,
+    @inject('ICategoryRepository')
+    private _categoryRepository: ICategoryRepository,
+
   ) {}
 
   private async processPackageImages(images: { key: string; status: string }[]): Promise<IFile[]> {
@@ -121,7 +123,8 @@ export class PackageService implements IPackageService {
     payload: CreateBasePackageDTO,
   ): Promise<{ packageId: string }> {
     const vendorObjectId = toObjectId(vendorId);
-
+    
+    console.log('creation data', payload)
     // Step 1 — Only approved vendors can create packages
     const vendor = await this._vendorInfoRepository.findVendorWithUserId(vendorId);
 
@@ -141,8 +144,19 @@ export class PackageService implements IPackageService {
         throw new AppError(ERROR_MESSAGES.PACKAGE_ALREADY_EXISTS, HTTP_STATUS.CONFLICT);
       }
     }
+    
+    let categoryObjectId: Types.ObjectId | undefined;
+    if (payload.categoryId) {
+      categoryObjectId = toObjectId(payload.categoryId);
+        const category = await this._categoryRepository.findById(payload.categoryId);
 
-    // Step 3 — Process images if any were sent
+      if (!category) {
+       throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
+      }
+      if (!category.isActive) {
+        throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_ACTIVE, HTTP_STATUS.BAD_REQUEST);
+      }
+    }
     let imageKeys: IFile[] | undefined;
     if (payload.images && payload.images.length > 0) {
       imageKeys = await this.processPackageImages(payload.images);
@@ -151,6 +165,7 @@ export class PackageService implements IPackageService {
     const newPackage = await this._basePackageRepository.create({
       ...payload,
       vendorId: vendorObjectId,
+      ...(categoryObjectId && { categoryId: categoryObjectId }),
       ...(imageKeys && { images: imageKeys }),
     });
 

--- a/src/services/vendor/package.service.ts
+++ b/src/services/vendor/package.service.ts
@@ -13,13 +13,13 @@ import { HTTP_STATUS } from '../../shared/constants/http_status_code';
 import { Types } from 'mongoose';
 import { toObjectId } from '../../shared/utils/database/objectId.helper';
 import { PaginatedData } from '../../types/common/IPaginationResponse';
-import { BasePackageSingleResponseDTO } from '../../types/dtos/admin/response.dtos';
-import { CustomQueryOptions } from '../../types/common/IQueryOptions';
-import { FilterQuery } from 'mongoose';
-import { IBasePackageEntity, IFile } from '../../types/entities/base-package.entity';
+import { BasePackageSingleResponseDTO, PackageDetailDTO } from '../../types/dtos/admin/response.dtos';
 import { PACKAGE_STATUS } from '../../shared/constants/constants';
 import { IFileStorageHandlerService } from '../../interfaces/service_interfaces/IFileStorageBusinessService';
 import { ICategoryRepository } from '../../interfaces/repository_interfaces/ICategoryRepository';
+import { FilterType } from 'types/db';
+import { PackageMapper } from '../../shared/mappers/package.mapper';
+import { IBasePackagePopulated, IFile } from 'types/entities/base-package.entity';
 @injectable()
 export class PackageService implements IPackageService {
   constructor(
@@ -31,7 +31,6 @@ export class PackageService implements IPackageService {
     private _fileStorageHandlerService: IFileStorageHandlerService,
     @inject('ICategoryRepository')
     private _categoryRepository: ICategoryRepository,
-
   ) {}
 
   private async processPackageImages(images: { key: string; status: string }[]): Promise<IFile[]> {
@@ -46,75 +45,33 @@ export class PackageService implements IPackageService {
   //=======================================
   async fetchPackages(
     vendorId: string,
-    page: number,
-    limit: number,
-    search?: string,
-    selectedFilter?: string,
+    filters: FilterType,
   ): Promise<PaginatedData<BasePackageSingleResponseDTO>> {
-    const skip = (page - 1) * limit;
-
-    const query: FilterQuery<IBasePackageEntity> = {
-      vendorId,
-    };
-    if (search) {
-      query.title = { $regex: search, $options: 'i' };
-    }
-    if (selectedFilter && selectedFilter !== 'all') {
-      query.status = selectedFilter;
-    }
-
-    const options = {
-      skip,
-      limit,
-      sort: { createdAt: -1 },
-    };
-
-    const [packages, totalDocs] = await Promise.all([
-      this._basePackageRepository.findAll(query, options),
-      this._basePackageRepository.countDocuments(query),
-    ]);
-
-    const packageData: BasePackageSingleResponseDTO[] = packages.map((pkg) => ({
-      id: pkg._id.toString(),
-      title: pkg.title ?? '',
-      location: pkg.location ?? '',
-      durationDays: pkg.days ?? 0,
-      durationNights: pkg.nights ?? 0,
-      imageUrl: pkg.images?.map((image: IFile) => ({ key: image.key })) ?? [],
-      status: pkg.status,
-      category: pkg.category ?? '',
-      difficultyLevel: pkg.difficultyLevel ?? '',
-      basePrice: pkg.basePrice ?? 0,
-    }));
-
+ 
+    const { requests, total } = await this._basePackageRepository.findPackages(vendorId, filters);
     const response = {
-      data: packageData,
-      currentPage: page,
-      totalPages: Math.ceil(totalDocs / limit),
-      totalDocs,
+      data: requests.map(PackageMapper.toResponse),
+      currentPage: filters.page,
+      totalPages: Math.ceil(total / filters.limit),
+      totalDocs: total,
     };
     return response;
   }
   //====================================================================
 
-  async fetchPackagesWithId(vendorId: string, packageId: string): Promise<BasePackageResponseDTO> {
+  async fetchPackagesWithId(vendorId: string, packageId: string): Promise<PackageDetailDTO> {
     const vendorObjectId = toObjectId(vendorId);
     const packageObjectId = toObjectId(packageId);
 
-    const packageExist = await this._basePackageRepository.findOne({
-      _id: packageObjectId,
-      vendorId: vendorObjectId,
-    });
+    const packageExist = await this._basePackageRepository.findOnePopulated<IBasePackagePopulated>({
+      _id: packageObjectId,vendorId: vendorObjectId,},
+      { path: 'categoryId', select: 'name' }
+    );
 
     if (!packageExist) {
       throw new AppError(ERROR_MESSAGES.PACKAGE_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
     }
-
-    return {
-      ...packageExist.toObject(),
-      packageId: packageExist._id.toString(),
-      vendorId: vendorObjectId.toString(),
-    };
+    return PackageMapper.toDetailResponse(packageExist);
   }
 
   //==================================================================
@@ -123,8 +80,6 @@ export class PackageService implements IPackageService {
     payload: CreateBasePackageDTO,
   ): Promise<{ packageId: string }> {
     const vendorObjectId = toObjectId(vendorId);
-    
-    console.log('creation data', payload)
     // Step 1 — Only approved vendors can create packages
     const vendor = await this._vendorInfoRepository.findVendorWithUserId(vendorId);
 
@@ -144,14 +99,14 @@ export class PackageService implements IPackageService {
         throw new AppError(ERROR_MESSAGES.PACKAGE_ALREADY_EXISTS, HTTP_STATUS.CONFLICT);
       }
     }
-    
+
     let categoryObjectId: Types.ObjectId | undefined;
     if (payload.categoryId) {
       categoryObjectId = toObjectId(payload.categoryId);
-        const category = await this._categoryRepository.findById(payload.categoryId);
+      const category = await this._categoryRepository.findById(payload.categoryId);
 
       if (!category) {
-       throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
+        throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
       }
       if (!category.isActive) {
         throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_ACTIVE, HTTP_STATUS.BAD_REQUEST);
@@ -161,9 +116,10 @@ export class PackageService implements IPackageService {
     if (payload.images && payload.images.length > 0) {
       imageKeys = await this.processPackageImages(payload.images);
     }
+    const { categoryId, images, ...restPayload } = payload;
 
     const newPackage = await this._basePackageRepository.create({
-      ...payload,
+      ...restPayload,
       vendorId: vendorObjectId,
       ...(categoryObjectId && { categoryId: categoryObjectId }),
       ...(imageKeys && { images: imageKeys }),
@@ -192,6 +148,20 @@ export class PackageService implements IPackageService {
       throw new AppError(ERROR_MESSAGES.PACKAGE_CANNOT_EDIT, HTTP_STATUS.BAD_REQUEST);
     }
 
+    const { categoryId, ...restPayload } = payload;
+    let categoryObjectId: Types.ObjectId | undefined;
+
+    if (categoryId) {
+      const category = await this._categoryRepository.findById(categoryId);
+      if (!category) {
+        throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_FOUND, HTTP_STATUS.NOT_FOUND);
+      }
+      if (!category.isActive) {
+        throw new AppError(ERROR_MESSAGES.CATEGORY_NOT_ACTIVE, HTTP_STATUS.BAD_REQUEST);
+      }
+      categoryObjectId = toObjectId(categoryId);
+    }
+
     let imageKeys: IFile[] | undefined;
 
     if (payload.images) {
@@ -201,7 +171,8 @@ export class PackageService implements IPackageService {
     await this._basePackageRepository.findOneAndUpdate(
       { _id: packageObjectId },
       {
-        ...payload,
+        ...restPayload,
+        ...(categoryObjectId && { categoryId: categoryObjectId }),
         ...(imageKeys && { images: imageKeys }),
       },
     );

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -4,6 +4,8 @@ export const PACKAGE_STATUS = {
   SOFT_DELETED: 'SOFT_DELETED',
 } as const;
 
+export type PackageStatus = (typeof PACKAGE_STATUS)[keyof typeof PACKAGE_STATUS];
+
 export const CATEGORY_STATUS = {
   ACTIVE: 'active',
   INACTIVE: 'inactive',

--- a/src/shared/constants/messages.ts
+++ b/src/shared/constants/messages.ts
@@ -90,5 +90,5 @@ export const ERROR_MESSAGES = {
   CATEGORY_CANNOT_EDIT: 'This Category cannot be edited',
   CATEGORY_REQUEST_NOT_FOUND: 'Category request not found',
   CANNOT_TOGGLE: 'Cannot toggle status of a vendor category request.',
-  CATEGORY_NOT_ACTIVE:'Selected category is no longer active'
+  CATEGORY_NOT_ACTIVE: 'Selected category is no longer active',
 } as const;

--- a/src/shared/constants/messages.ts
+++ b/src/shared/constants/messages.ts
@@ -90,4 +90,5 @@ export const ERROR_MESSAGES = {
   CATEGORY_CANNOT_EDIT: 'This Category cannot be edited',
   CATEGORY_REQUEST_NOT_FOUND: 'Category request not found',
   CANNOT_TOGGLE: 'Cannot toggle status of a vendor category request.',
+  CATEGORY_NOT_ACTIVE:'Selected category is no longer active'
 } as const;

--- a/src/shared/mappers/category.mapper.ts
+++ b/src/shared/mappers/category.mapper.ts
@@ -3,7 +3,7 @@ import {
   CategoryRequestReviewedResponseDTO,
   CategoryResponseDTO,
 } from 'types/dtos/admin/response.dtos';
-import { VendorRequestedCategoryResponseDTO } from 'types/dtos/vendor/response.dtos';
+import { ActiveCategoriesResponseDTO, VendorRequestedCategoryResponseDTO } from 'types/dtos/vendor/response.dtos';
 import { ICategory, ICategoryRequestPopulated } from 'types/entities/category.entity';
 
 const DATE_FORMAT = new Intl.DateTimeFormat('en-US', {
@@ -64,6 +64,13 @@ export class CategoryMapper {
       note: cat.vendorNote ?? null,
       createdAt: DATE_FORMAT.format(cat.updatedAt),
       status: cat.status,
+    };
+  }
+
+  static toActiveCategoriesResponse(cat: ICategory): ActiveCategoriesResponseDTO {
+    return {
+      id: cat._id.toString(),
+      name: cat.name,
     };
   }
 }

--- a/src/shared/mappers/category.mapper.ts
+++ b/src/shared/mappers/category.mapper.ts
@@ -3,7 +3,10 @@ import {
   CategoryRequestReviewedResponseDTO,
   CategoryResponseDTO,
 } from 'types/dtos/admin/response.dtos';
-import { ActiveCategoriesResponseDTO, VendorRequestedCategoryResponseDTO } from 'types/dtos/vendor/response.dtos';
+import {
+  ActiveCategoriesResponseDTO,
+  VendorRequestedCategoryResponseDTO,
+} from 'types/dtos/vendor/response.dtos';
 import { ICategory, ICategoryRequestPopulated } from 'types/entities/category.entity';
 
 const DATE_FORMAT = new Intl.DateTimeFormat('en-US', {

--- a/src/shared/mappers/package.mapper.ts
+++ b/src/shared/mappers/package.mapper.ts
@@ -1,0 +1,61 @@
+import { BasePackageSingleResponseDTO, PackageDetailDTO } from 'types/dtos/admin/response.dtos';
+import { IBasePackagePopulated, IFile } from 'types/entities/base-package.entity';
+
+export class PackageMapper {
+  static toResponse(pkg: IBasePackagePopulated): BasePackageSingleResponseDTO {
+    return {
+      id: pkg._id.toString(),
+      title: pkg.title ?? '',
+      location: pkg.location ?? '',
+      state:pkg.state ?? '',
+      durationDays: Number(pkg.days) ?? 0,
+      durationNights: Number(pkg.nights) ?? 0,
+      imageUrl: pkg.images?.map((image: IFile) => ({ key: image.key })) ?? [],
+      status: pkg.status,
+      category: pkg.categoryId?.name ?? '',
+      difficultyLevel: pkg.difficultyLevel ?? '',
+      basePrice: Number(pkg.basePrice) ?? 0,
+    };
+    }
+    
+   static toDetailResponse(pkg: IBasePackagePopulated): PackageDetailDTO {
+     return {
+      packageId: pkg._id.toString(),
+      vendorId: pkg.vendorId.toString(),
+      title: pkg.title ?? '',
+      location: pkg.location ?? '',
+      state: pkg.state ?? '',
+      usp: pkg.usp ?? '',
+      category: pkg.categoryId?.name ?? null,
+      difficultyLevel: pkg.difficultyLevel ?? undefined,
+      description: pkg.description ?? '',
+      days: pkg.days ?? '',
+      nights: pkg.nights ?? '',
+      basePrice: pkg.basePrice ?? '',
+      images: pkg.images?.map((image: IFile) => ({ key: image.key })) ?? [],
+      itinerary: pkg.itinerary?.map((day) => ({
+        dayNumber: day.dayNumber ?? 0,
+        title: day.title ?? '',
+        activities: day.activities?.map((activity) => ({
+          startTime: activity.startTime ?? '',
+          endTime: activity.endTime ?? '',
+          title: activity.title ?? '',
+          description: activity.description ?? '',
+          location: activity.location ?? '',
+          specials: activity.specials ?? [],
+          included: activity.included ?? false,
+        })) ?? [],
+      })) ?? [],
+      inclusions: pkg.inclusions ?? [],
+      exclusions: pkg.exclusions ?? [],
+      packingList: pkg.packingList ?? [],
+      cancellationPolicy: pkg.cancellationPolicy ?? null,
+      status: pkg.status,
+      isActive: pkg.isActive,
+      createdAt: pkg.createdAt,
+      updatedAt: pkg.updatedAt,
+    };
+  }
+}
+
+

--- a/src/shared/utils/database/objectId.helper.ts
+++ b/src/shared/utils/database/objectId.helper.ts
@@ -1,5 +1,3 @@
-// shared/database/objectId.helper.ts
-
 import { Types } from 'mongoose';
 import { AppError } from '../../../errors/AppError';
 import { HTTP_STATUS } from '../../../shared/constants/http_status_code';

--- a/src/types/dtos/admin/response.dtos.ts
+++ b/src/types/dtos/admin/response.dtos.ts
@@ -1,4 +1,4 @@
-import { IFile } from 'types/entities/base-package.entity';
+import { DifficultyLevel, IFile } from 'types/entities/base-package.entity';
 import { PackageStatus } from '../../../types/type';
 import { CategoryStatus } from '../../../shared/constants/constants';
 export interface UserResponseDTO {
@@ -10,10 +10,13 @@ export interface UserResponseDTO {
   createdAt: string;
 }
 
+
+// =========== package ==========
 export interface BasePackageSingleResponseDTO {
   id: string;
   title: string;
   location: string;
+  state: string;
   durationDays: number;
   durationNights: number;
   imageUrl?: IFile[];
@@ -23,6 +26,51 @@ export interface BasePackageSingleResponseDTO {
   basePrice: number;
 }
 
+
+
+export interface ActivityDTO {
+  startTime: string;
+  endTime: string;
+  title: string;
+  description: string;
+  location: string;
+  specials: string[];
+  included: boolean;
+}
+
+export interface ItineraryDayDTO {
+  dayNumber: number;
+  title: string;
+  activities: ActivityDTO[];
+}
+
+export interface PackageDetailDTO {
+  packageId: string;        
+  vendorId: string;         
+  title: string;
+  location: string;
+  state: string;
+  usp: string;
+  category: string | null; 
+  difficultyLevel: DifficultyLevel | undefined;
+  description: string;
+  days: string;
+  nights: string;
+  basePrice: string;
+  images: { key: string }[];
+  itinerary: ItineraryDayDTO[];
+  inclusions: string[];
+  exclusions: string[];
+  packingList: string[];
+  cancellationPolicy: string | null;
+  status: PackageStatus;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+
+//======= category =========
 export interface CategoryResponseDTO {
   id: string;
   name: string;

--- a/src/types/dtos/vendor/response.dtos.ts
+++ b/src/types/dtos/vendor/response.dtos.ts
@@ -24,3 +24,8 @@ export interface VendorRequestedCategoryResponseDTO {
   createdAt: string;
   status: CategoryStatus;
 }
+
+export interface ActiveCategoriesResponseDTO {
+  id: string;
+  name: string;
+}

--- a/src/types/entities/base-package.entity.ts
+++ b/src/types/entities/base-package.entity.ts
@@ -1,19 +1,15 @@
 import { Document, Types } from 'mongoose';
-
-export type PackageStatus = 'DRAFT' | 'PUBLISHED' | 'SOFT_DELETED';
+import { PackageStatus } from 'shared/constants/constants';
 export interface IFile {
   key: string;
 }
-
-export type ActivityType = 'travel' | 'meal' | 'stay' | 'sightseeing' | 'activity' | 'free';
-
 export interface Activity {
   startTime?: string;
   endTime?: string;
   title?: string;
   description?: string;
   location?: string;
-  type?: ActivityType;
+  specials?: string[];
   included?: boolean;
 }
 export interface DayItinerary {
@@ -22,18 +18,16 @@ export interface DayItinerary {
   activities?: Activity[];
 }
 
-export type PackageCategory = 'weekend' | 'adventure' | 'family' | 'honeymoon';
 
-export type DifficultyLevel = 'easy' | 'moderate' | 'hard';
+export type DifficultyLevel = 'easy'| 'moderate'| 'challenging'| 'extreme';
 
 export interface IBasePackageEntity extends Document {
   vendorId: Types.ObjectId;
 
   title?: string;
   location?: string;
-  pickupLocation?: string;
   usp?: string;
-  category?: PackageCategory;
+  categoryId?: Types.ObjectId;
 
   images?: IFile[];
 

--- a/src/types/entities/base-package.entity.ts
+++ b/src/types/entities/base-package.entity.ts
@@ -1,4 +1,4 @@
-import { Document, Types } from 'mongoose';
+import mongoose, { Document, Types } from 'mongoose';
 import { PackageStatus } from 'shared/constants/constants';
 export interface IFile {
   key: string;
@@ -18,37 +18,33 @@ export interface DayItinerary {
   activities?: Activity[];
 }
 
-
-export type DifficultyLevel = 'easy'| 'moderate'| 'challenging'| 'extreme';
+export type DifficultyLevel = 'Easy' | 'Moderate' | 'Challenging' | 'Extreme';
 
 export interface IBasePackageEntity extends Document {
+  _id: mongoose.Types.ObjectId;
   vendorId: Types.ObjectId;
-
   title?: string;
   location?: string;
+  state?: string;
   usp?: string;
   categoryId?: Types.ObjectId;
-
   images?: IFile[];
-
   days?: string;
   nights?: string;
-
   basePrice?: string;
   description?: string;
-
   itinerary?: DayItinerary[];
-
   inclusions?: string[];
   exclusions?: string[];
   packingList?: string[];
   cancellationPolicy?: 'Flexible' | 'Moderate' | 'Strict' | 'Non-Refundable';
-
   difficultyLevel?: DifficultyLevel;
-
   status: PackageStatus;
   isActive: boolean;
-
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface IBasePackagePopulated extends Omit<IBasePackageEntity, 'categoryId'> {
+  categoryId: { name: string };
 }

--- a/src/validators/vendor/package/base-package.schema.ts
+++ b/src/validators/vendor/package/base-package.schema.ts
@@ -1,29 +1,8 @@
 import { PACKAGE_STATUS } from '../../../shared/constants/constants';
 import z from 'zod';
 
-export const CATEGORY_ENUM = [
-  'weekend',
-  'adventure',
-  'family',
-  'honeymoon',
-  'cultural',
-  'relaxation',
-  'luxury',
-] as const;
 
 export const DIFFICULTY_ENUM = ['easy', 'moderate', 'hard', 'challenging', 'extreme'] as const;
-
-export const ACTIVITY_TYPE_ENUM = [
-  'travel',
-  'meal',
-  'stay',
-  'sightseeing',
-  'activity',
-  'free',
-  'tour',
-  'transport',
-  'accommodation',
-] as const;
 
 const basePackageBackendSchema = z.object({
   status: z.nativeEnum(PACKAGE_STATUS),
@@ -41,7 +20,7 @@ const draftActivitySchema = z.object({
   title: z.string().optional(),
   description: z.string().optional(),
   location: z.string().optional(),
-  type: z.enum(ACTIVITY_TYPE_ENUM).optional(),
+  specials: z.array(z.string()).transform(arr => arr.filter(s => s.trim() !== "")),
   included: z.boolean().optional(),
 });
 
@@ -55,13 +34,12 @@ const draftPackageBackendSchema = basePackageBackendSchema.extend({
   title: z.string().min(3).optional(),
   location: z.string().optional(),
   usp: z.string().optional(),
-  pickupLocation: z.string().optional(),
   description: z.string().optional(),
 
   images: z.array(packageImageSchema).optional(),
   itinerary: z.array(draftItineraryDaySchema).optional(),
 
-  category: z.enum(CATEGORY_ENUM).optional(),
+  categoryId: z.string().optional(),
   difficultyLevel: z.enum(DIFFICULTY_ENUM).optional(),
 
   days: z.string().optional(),
@@ -104,9 +82,7 @@ const createActivitySchema = z.object({
 
   location: z.string().min(2, 'Activity location is required'),
 
-  type: z.enum(ACTIVITY_TYPE_ENUM, {
-    errorMap: () => ({ message: 'Please select a valid activity type' }),
-  }),
+  specials: z.array(z.string().min(1, "Special cannot be empty")),
 
   included: z.boolean(),
 });
@@ -139,9 +115,7 @@ export const publishPackageBackendSchema = basePackageBackendSchema
       .min(2, 'USP must be at least 2 characters')
       .max(100, 'USP must be at most 100 characters'),
 
-    category: z.enum(CATEGORY_ENUM, {
-      errorMap: () => ({ message: 'Please select a valid category' }),
-    }),
+    categoryId: z.string().regex(/^[0-9a-fA-F]{24}$/, "Invalid category"),
 
     difficultyLevel: z.enum(DIFFICULTY_ENUM, {
       errorMap: () => ({ message: 'Please select a valid difficulty level' }),

--- a/src/validators/vendor/package/base-package.schema.ts
+++ b/src/validators/vendor/package/base-package.schema.ts
@@ -1,8 +1,7 @@
 import { PACKAGE_STATUS } from '../../../shared/constants/constants';
 import z from 'zod';
 
-
-export const DIFFICULTY_ENUM = ['easy', 'moderate', 'hard', 'challenging', 'extreme'] as const;
+export const DIFFICULTY_ENUM = ['Easy', 'Moderate', 'Challenging', 'Extreme'] as const;
 
 const basePackageBackendSchema = z.object({
   status: z.nativeEnum(PACKAGE_STATUS),
@@ -20,7 +19,7 @@ const draftActivitySchema = z.object({
   title: z.string().optional(),
   description: z.string().optional(),
   location: z.string().optional(),
-  specials: z.array(z.string()).transform(arr => arr.filter(s => s.trim() !== "")),
+  specials: z.array(z.string()).transform((arr) => arr.filter((s) => s.trim() !== '')),
   included: z.boolean().optional(),
 });
 
@@ -33,6 +32,7 @@ const draftItineraryDaySchema = z.object({
 const draftPackageBackendSchema = basePackageBackendSchema.extend({
   title: z.string().min(3).optional(),
   location: z.string().optional(),
+  state: z.string().optional(),
   usp: z.string().optional(),
   description: z.string().optional(),
 
@@ -80,9 +80,9 @@ const createActivitySchema = z.object({
     .min(10, 'Description must be at least 10 characters')
     .max(1000, 'Description must be at most 1000 characters'),
 
-  location: z.string().min(2, 'Activity location is required'),
+  location: z.string().min(3, 'Activity location is required'),
 
-  specials: z.array(z.string().min(1, "Special cannot be empty")),
+  specials: z.array(z.string().min(1, 'Special cannot be empty')),
 
   included: z.boolean(),
 });
@@ -102,20 +102,20 @@ export const publishPackageBackendSchema = basePackageBackendSchema
 
     location: z
       .string()
-      .min(2, 'Location must be at least 2 characters')
+      .min(3, 'Location must be at least 2 characters')
       .max(100, 'Location must be at most 100 characters'),
-
-    pickupLocation: z
+    
+    state: z
       .string()
-      .min(2, 'Pickup location must be at least 2 characters')
-      .max(100, 'Pickup location must be at most 100 characters'),
+      .min(3, 'State must be at least 2 characters')
+      .max(100, 'State must be at most 100 characters'),
 
     usp: z
       .string()
       .min(2, 'USP must be at least 2 characters')
       .max(100, 'USP must be at most 100 characters'),
 
-    categoryId: z.string().regex(/^[0-9a-fA-F]{24}$/, "Invalid category"),
+    categoryId: z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid category'),
 
     difficultyLevel: z.enum(DIFFICULTY_ENUM, {
       errorMap: () => ({ message: 'Please select a valid difficulty level' }),


### PR DESCRIPTION
## Summary
Refactored the base package module to improve data integrity, 
type safety, and separation of concerns.

## Changes

 Package Mapper
- Added `PackageMapper` class with `toResponse` and `toDetailResponse` static methods

 DTOs
- Added `PackageDetailDTO` with proper typed fields (`ActivityDTO`, `ItineraryDayDTO`)
- Replaced raw mongoose document returns with mapped DTO responses

 Category Handling
- Added category existence and active status validation on package creation

Repository
- Added `findOnePopulated<P>` generic method to base repository and interface
- Supports typed populate results without leaking model access into service layer



